### PR TITLE
Participants see alerts dismiss after a delay

### DIFF
--- a/app/components/flash/component.html.erb
+++ b/app/components/flash/component.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag :flash, class: "contents" do %>
-  <% flash.each do |level, message| %>
-    <div class="max-w-sm w-full bg-white shadow-lg rounded-lg pointer-events-auto ring-1 ring-black ring-opacity-5 overflow-hidden" data-turbo-cache="false">
+  <% flash.each.with_index do |(level, message), index| %>
+    <div class="transition transform duration-1000 hidden max-w-sm w-full bg-white shadow-lg rounded-lg pointer-events-auto ring-1 ring-black ring-opacity-5 overflow-hidden mb-4" data-notification-delay-value="<%= 5000 + index * 200 %>" data-turbo-cache="false" data-controller="notification" data-transition-enter-from="opacity-0 translate-x-6" data-transition-enter-to="opacity-100 translate-x-0" data-transition-leave-from="opacity-100 translate-x-0" data-transition-leave-to="opacity-0 translate-x-6">
       <div class="p-4">
         <div class="flex items-start">
           <div class="flex-shrink-0">
@@ -10,7 +10,7 @@
             <p class="text-sm font-medium text-gray-900"><%= message %></p>
           </div>
           <div class="ml-4 flex-shrink-0 flex">
-            <button type="button" class="bg-white rounded-md inline-flex text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+            <button type="button" class="bg-white rounded-md inline-flex text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" data-action="notification#hide">
               <span class="sr-only">Close</span>
               <%= inline_svg_tag "flash/close.svg", class: 'h-5 w-5' %>
             </button>

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,8 +1,10 @@
 import { Application } from "@hotwired/stimulus"
 import Reveal from 'stimulus-reveal-controller'
+import Notification from 'stimulus-notification'
 
 const application = Application.start()
 application.register('reveal', Reveal)
+application.register('notification', Notification)
 
 // Configure Stimulus development experience
 application.debug = false

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,3 +6,7 @@ pin '@hotwired/stimulus', to: 'stimulus.min.js', preload: true
 pin '@hotwired/stimulus-loading', to: 'stimulus-loading.js', preload: true
 pin_all_from 'app/javascript/controllers', under: 'controllers'
 pin 'stimulus-reveal-controller', to: 'https://ga.jspm.io/npm:stimulus-reveal-controller@4.0.0/dist/stimulus-reveal-controller.es.js'
+pin 'stimulus-notification', to: 'https://ga.jspm.io/npm:stimulus-notification@2.0.0/dist/stimulus-notification.es.js'
+pin '@hotwired/stimulus', to: 'https://ga.jspm.io/npm:@hotwired/stimulus@3.0.1/dist/stimulus.js'
+pin 'hotkeys-js', to: 'https://ga.jspm.io/npm:hotkeys-js@3.9.4/dist/hotkeys.esm.js'
+pin 'stimulus-use', to: 'https://ga.jspm.io/npm:stimulus-use@0.50.0/dist/index.js'


### PR DESCRIPTION
## Describe your changes

This adds a Stimulus controller to flash messages, which results in those messages being dismissed gracefully after a couple seconds.

## Checklist before hitting the green button
- [x] My commit messages mention the impacted stories, e.g. `[#12345,#678910]`
- [x] If appropriate, my commit messages flag story state, e.g. `[Finishes #1234]` or `[Fixes #4567]` or `[Delivers #78910]`
