### PR TITLE
Participant sees more Boards when they scroll to the bottom

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'rails', '~> 7.0.3'
 gem 'redis', '~> 4.0'
 
 gem 'devise'
+gem 'geared_pagination', '~> 1.1'
 gem 'hotwire-livereload', '~> 1.2'
 gem 'image_processing', '~> 1.2'
 gem 'importmap-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,9 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.0.3)
     ffi (1.15.5)
+    geared_pagination (1.1.2)
+      activesupport (>= 5.0)
+      addressable (>= 2.5.0)
     gitlab (4.19.0)
       httparty (~> 0.20)
       terminal-table (>= 1.5.1)
@@ -426,6 +429,7 @@ DEPENDENCIES
   erb_lint
   factory_bot_rails
   faker
+  geared_pagination (~> 1.1)
   hotwire-livereload (~> 1.2)
   image_processing (~> 1.2)
   importmap-rails

--- a/app/components/board/component.html.erb
+++ b/app/components/board/component.html.erb
@@ -1,5 +1,5 @@
 <li id="<%= dom_id(board) %>">
-  <%= link_to board, class: 'block hover:bg-gray-50' do %>
+  <%= link_to board, class: 'block hover:bg-gray-50', data: {turbo_frame: '_top'} do %>
     <div class="px-4 py-4 flex items-center sm:px-6">
       <div class="min-w-0 flex-1 sm:flex sm:items-center sm:justify-between">
         <div class="truncate">

--- a/app/components/boards_list/component.html.erb
+++ b/app/components/boards_list/component.html.erb
@@ -1,5 +1,16 @@
 <div class="bg-white shadow overflow-hidden sm:rounded-md">
   <ul id="boards" role="list" class="divide-y divide-gray-200">
-    <%= render(Board::Component.with_collection(boards)) %>
+    <%= turbo_frame_tag [:boards, boards.number - 1] do %>
+      <%= render(Board::Component.with_collection(boards.records)) %>
+      <%= turbo_frame_tag [:boards, boards.number] do %>
+        <% unless boards.last? %>
+          <nav class="bg-white px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6" aria-label="Pagination">
+            <div class="flex-1 flex justify-between sm:justify-end">
+              <%= link_to 'Next', boards_path(page: boards.next_param), class: 'ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50', data: {controller: :autoclick} %>
+            </div>
+          </nav>
+        <% end %>
+      <% end %>
+    <% end %>
   </ul>
 </div>

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -97,7 +97,7 @@ class BoardsController < ApplicationController
   end
 
   def index
-    @boards = Board.most_recent
+    set_page_and_extract_portion_from Board.all, ordered_by: {created_at: :desc, id: :desc}
   end
 
   def show

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,4 +1,4 @@
-import { Application } from "@hotwired/stimulus"
+import { Application } from '@hotwired/stimulus'
 import Reveal from 'stimulus-reveal-controller'
 import Notification from 'stimulus-notification'
 import RailsNestedForm from 'stimulus-rails-nested-form'

--- a/app/javascript/controllers/autoclick_controller.js
+++ b/app/javascript/controllers/autoclick_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from '@hotwired/stimulus'
+import { useIntersection } from 'stimulus-use'
+
+export default class extends Controller {
+  options = {threshold: 0}
+
+  connect() {
+    useIntersection(this, this.options)
+  }
+
+  appear(entry) {
+    this.element.click()
+  }
+}

--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -9,5 +9,5 @@
 
 <div class="mt-4 max-w-7xl mx-auto sm:px-6 lg:px-8">
   <%= turbo_stream_from 'boards' %>
-  <%= render(BoardsList::Component.new(boards: @boards)) %>
+  <%= render(BoardsList::Component.new(boards: @page)) %>
 </div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,13 +1,13 @@
 # Pin npm packages by running ./bin/importmap
 
-pin 'application', preload: true
-pin '@hotwired/turbo-rails', to: 'turbo.min.js', preload: true
+pin '@hotwired/stimulus', to: 'https://ga.jspm.io/npm:@hotwired/stimulus@3.1.0/dist/stimulus.js'
 pin '@hotwired/stimulus', to: 'stimulus.min.js', preload: true
 pin '@hotwired/stimulus-loading', to: 'stimulus-loading.js', preload: true
-pin_all_from 'app/javascript/controllers', under: 'controllers'
-pin 'stimulus-reveal-controller', to: 'https://ga.jspm.io/npm:stimulus-reveal-controller@4.0.0/dist/stimulus-reveal-controller.es.js'
-pin 'stimulus-notification', to: 'https://ga.jspm.io/npm:stimulus-notification@2.0.0/dist/stimulus-notification.es.js'
-pin '@hotwired/stimulus', to: 'https://ga.jspm.io/npm:@hotwired/stimulus@3.0.1/dist/stimulus.js'
+pin '@hotwired/turbo-rails', to: 'turbo.min.js', preload: true
+pin 'application', preload: true
 pin 'hotkeys-js', to: 'https://ga.jspm.io/npm:hotkeys-js@3.9.4/dist/hotkeys.esm.js'
-pin 'stimulus-use', to: 'https://ga.jspm.io/npm:stimulus-use@0.50.0/dist/index.js'
+pin 'stimulus-notification', to: 'https://ga.jspm.io/npm:stimulus-notification@2.0.0/dist/stimulus-notification.es.js'
 pin 'stimulus-rails-nested-form', to: 'https://ga.jspm.io/npm:stimulus-rails-nested-form@4.0.0/dist/stimulus-rails-nested-form.es.js'
+pin 'stimulus-reveal-controller', to: 'https://ga.jspm.io/npm:stimulus-reveal-controller@4.0.0/dist/stimulus-reveal-controller.es.js'
+pin 'stimulus-use', to: 'https://ga.jspm.io/npm:stimulus-use@0.50.0/dist/index.js'
+pin_all_from 'app/javascript/controllers', under: 'controllers'

--- a/spec/components/boards_list/component_spec.rb
+++ b/spec/components/boards_list/component_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe BoardsList::Component, type: :component do
-  subject(:rendered) { render_inline(described_class.new(boards: Board.all)) }
+  subject(:rendered) { render_inline(described_class.new(boards: boards)) }
+
+  let(:boards) { GearedPagination::Recordset.new(Board.all, ordered_by: {created_at: :desc, id: :desc}).page(nil) }
 
   context 'when there is a board' do
     before { create(:board, name: 'Longboard') }

--- a/spec/system/creating_a_retrospective_spec.rb
+++ b/spec/system/creating_a_retrospective_spec.rb
@@ -4,12 +4,15 @@ RSpec.describe 'Creating a retrospective', js: true do
   before do
     OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(uid: '123545', info: {email: 'user@ministryofvelocity.com', name: 'User', image: 'https://placekitten.com/80/80'})
     Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:google_oauth2]
+    create_list(:board, 16)
   end
 
   it 'adds a board' do
     visit root_path
 
     click_on 'Sign in'
+
+    expect(page.all('li').size).to eq(15)
 
     click_on 'New Board'
 
@@ -28,6 +31,13 @@ RSpec.describe 'Creating a retrospective', js: true do
     click_on 'Create Board'
 
     expect(page).to have_content("Today's Retro").and have_text(I18n.l(Time.current.utc.to_date, format: :long))
+    expect(page.all('li').size).to eq(16)
+
+    scroll_to page.find('a', text: 'Next')
+
+    expect(page).to have_no_link('Next')
+
+    expect(page.all('li').size).to eq(17)
 
     click_on "Today's Retro"
 


### PR DESCRIPTION
## Describe your changes

When there are a lot of Boards in the list, the page might take a long time to load. This commit adds a Next button at the end of the Boards list, and automatically clicks that button when it's in view.

## Checklist before hitting the green button
- [x] My commit messages mention the impacted stories, e.g. `[#12345,#678910]`
- [x] If appropriate, my commit messages flag story state, e.g. `[Finishes #1234]` or `[Fixes #4567]` or `[Delivers #78910]`
