### PR TITLE
Participant sees local times in their time zone

### DIFF
--- a/app/components/board/component.html.erb
+++ b/app/components/board/component.html.erb
@@ -7,7 +7,10 @@
           <div class="mt-2 flex">
             <div class="flex items-center text-sm text-gray-500">
               <%= inline_svg_tag 'board/calendar.svg', class: 'flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400' %>
-              <p><span class="sr-only">Created on </span><%= time_tag board.created_at %></p>
+              <p>
+                <span class="sr-only">Created on</span>
+                <%= time_tag board.created_at, data: {controller: 'local-time'} %>
+              </p>
             </div>
           </div>
         </div>

--- a/app/javascript/controllers/local_time_controller.js
+++ b/app/javascript/controllers/local_time_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  connect() {
+    const time = this.element.getAttribute('datetime')
+    const parsed = new Date(time)
+    const dateFormat = new Intl.DateTimeFormat('en', {dateStyle: 'long'})
+    const timeFormat = new Intl.DateTimeFormat('en', {timeStyle: 'short'})
+    this.element.innerText = `${dateFormat.format(parsed)} ${timeFormat.format(parsed)}`
+  }
+}

--- a/spec/system/creating_a_retrospective_spec.rb
+++ b/spec/system/creating_a_retrospective_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Creating a retrospective', js: true do
 
     click_on 'Create Board'
 
-    expect(page).to have_content("Today's Retro").and have_text(I18n.l(Time.current.utc.to_date, format: :long))
+    expect(page).to have_content("Today's Retro").and have_text(I18n.l(Time.now.getlocal.to_date, format: :long))
     expect(page.all('li').size).to eq(16)
 
     scroll_to page.find('a', text: 'Next')


### PR DESCRIPTION
## Describe your changes

When a Participant the list of Boards, they see creation times in their local timezone

## Checklist before hitting the green button
- [x] My commit messages mention the impacted stories, e.g. `[#12345,#678910]`
- [x] If appropriate, my commit messages flag story state, e.g. `[Finishes #1234]` or `[Fixes #4567]` or `[Delivers #78910]`
