### PR TITLE
Facilitator can set a timer on a Board

### DIFF
--- a/app/assets/images/timer/chevron_down.svg
+++ b/app/assets/images/timer/chevron_down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+  <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+</svg>

--- a/app/components/board_header/component.html.erb
+++ b/app/components/board_header/component.html.erb
@@ -1,10 +1,16 @@
 <%= turbo_frame_tag dom_id(board, :header) do %>
-  <div class="flex space-x-4 items-center">
-    <h2 class="text-3xl font-bold leading-tight text-gray-900"><%= board.name %></h2>
-
-    <%= link_to [:edit, board], class: 'inline-flex justify-center px-2 py-2 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900', data: {turbo_frame: 'slideover'} do %>
-      <%= inline_svg_tag 'board_header/pencil.svg', class: 'h-5 w-5 text-gray-400' %>
-      <span class="sr-only">Edit Board</span>
-    <% end %>
+  <div class="pb-5 border-b border-gray-200 sm:flex sm:items-center sm:justify-between">
+    <h2 class="text-2xl font-bold leading-7 text-gray-900 sm:text-3xl sm:truncate"><%= board.name %></h2>
+    <div class="mt-3 flex justify-end sm:mt-0 sm:ml-4">
+      <div class="flex-1 sm:order-1 sm:ml-4">
+        <%= link_to [:edit, board], class: 'inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500', data: {turbo_frame: 'slideover'} do %>
+          <%= inline_svg_tag 'board_header/pencil.svg', class: 'h-5 w-5 mr-2 text-gray-400' %>
+          Edit<span class="sr-only"> Board</span>
+        <% end %>
+      </div>
+      <div>
+        <%= turbo_frame_tag dom_id(board, :timer), src: board_timer_path(board) %>
+      </div>
+    </div>
   </div>
 <% end %>

--- a/app/components/timer/component.html.erb
+++ b/app/components/timer/component.html.erb
@@ -1,0 +1,28 @@
+<%= turbo_frame_tag dom_id(timer.board, :timer) do %>
+  <div class="relative inline-block text-left" data-controller="dropdown">
+    <div>
+      <%= button_tag type: 'button', class: 'inline-flex justify-center w-full rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-indigo-500', data: {action: 'dropdown#toggle click@window->dropdown#hide'} do %>
+        <% if timer.persisted? %>
+          <time class="font-mono" datetime="<%= timer.ends_at.iso8601 %>" data-controller="timer" data-timer-refresh-interval-value="250" data-timer-datetime-value="<%= timer.ends_at.iso8601 %>"><%= time_remaining %></time>
+        <% else %>
+          Start Timer
+        <% end %>
+        <%= inline_svg_tag 'timer/chevron_down.svg', class: '-mr-1 ml-2 h-5 w-5' %>
+      <% end %>
+    </div>
+
+    <div role="menu"
+      class="origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none"
+      data-dropdown-target="menu"
+      data-transition-enter-from="opacity-0 scale-95"
+      data-transition-enter-to="opacity-100 scale-100"
+      data-transition-leave-from="opacity-100 scale-100"
+      data-transition-leave-to="opacity-0 scale-95"
+      aria-orientation="vertical" aria-labelledby="menu-button" tabindex="-1">
+      <div class="py-1" role="none">
+        <%= button_to 'Stop Timer', board_timer_path(timer.board), method: :delete, class: 'text-gray-700 block px-4 py-2 text-sm', role: 'menuitem', data: {action: 'dropdown#toggle'} if timer.persisted? %>
+        <%= button_to '5 minutes', board_timer_path(timer.board), class: 'text-gray-700 block px-4 py-2 text-sm', role: 'menuitem', params: {timer: {duration: 5.minutes}}, data: {action: 'dropdown#toggle'} %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/components/timer/component.rb
+++ b/app/components/timer/component.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Timer::Component < ApplicationComponent
+  attr_reader :timer
+
+  def initialize(timer:)
+    @timer = timer
+  end
+
+  def time_remaining
+    if duration_parts.length < 1
+      duration_parts.last
+    elsif duration_parts.last < 10
+      (duration_parts[0..-2] + ['%02d' % duration_parts.last]).join(':')
+    else
+      duration_parts.join(':')
+    end
+  end
+
+  private
+
+  def duration_parts
+    ActiveSupport::Duration.build(timer.duration)
+      .parts
+      .reverse_merge(days: 0, hours: 0, minutes: 0, seconds: 0)
+      .values_at(:days, :hours, :minutes, :seconds)
+      .drop_while(&:zero?)
+  end
+end

--- a/app/controllers/boards/timers_controller.rb
+++ b/app/controllers/boards/timers_controller.rb
@@ -1,0 +1,88 @@
+class Boards::TimersController < ApplicationController
+  before_action :authenticate_user!
+
+  class TimerForm
+    include ActiveModel::Model
+
+    attr_accessor :board
+    attr_reader :duration
+
+    delegate :timer, to: :board, allow_nil: true
+    delegate :ends_at, to: :timer, allow_nil: true
+
+    validates :duration, numericality: {greater_than: 0}, on: :create
+    validates :persisted?, inclusion: {in: [true]}, on: :destroy
+
+    def duration=(value)
+      @duration = value.to_i
+    end
+
+    def persisted?
+      board.timer&.persisted?
+    end
+
+    def create(view_context)
+      return false unless valid?(:create)
+
+      board.timer = Timer.new(duration: duration)
+      board.broadcast_replace_later_to(
+        board,
+        target: view_context.dom_id(board, :timer),
+        html: Timer::Component.new(timer: board.timer).render_in(view_context)
+      )
+      true
+    end
+
+    def destroy(view_context)
+      return false unless valid?(:destroy)
+
+      board.timer.destroy
+      board.broadcast_replace_later_to(
+        board,
+        target: view_context.dom_id(board, :timer),
+        html: Timer::Component.new(timer: board.timer).render_in(view_context)
+      )
+      true
+    end
+  end
+
+  def show
+    @timer = TimerForm.new(board: current_board, duration: current_board.timer&.duration)
+  end
+
+  def create
+    @timer = TimerForm.new(timer_params.merge(board: current_board))
+
+    respond_to do |format|
+      if @timer.create(view_context)
+        format.turbo_stream { flash.now[:notice] = t('.success') }
+        format.html { redirect_to board_timer_url(current_board), notice: t('.success') }
+      else
+        format.html { render :show, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def destroy
+    @timer = TimerForm.new(board: current_board)
+
+    respond_to do |format|
+      if @timer.destroy(view_context)
+        format.turbo_stream { flash.now[:notice] = t('.success') }
+        format.html { redirect_to board_timer_url(current_board), notice: t('.success') }
+      else
+        format.html { redirect_to board_timer_url(current_board) }
+      end
+    end
+  end
+
+  private
+
+  def current_board
+    @current_board ||= Board.find(params[:board_id])
+  end
+
+  def timer_params
+    params.require(:timer).permit(:duration)
+  end
+end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -2,11 +2,13 @@ import { Application } from '@hotwired/stimulus'
 import Reveal from 'stimulus-reveal-controller'
 import Notification from 'stimulus-notification'
 import RailsNestedForm from 'stimulus-rails-nested-form'
+import Dropdown from 'stimulus-dropdown'
 
 const application = Application.start()
 application.register('reveal', Reveal)
 application.register('notification', Notification)
 application.register('nested-form', RailsNestedForm)
+application.register('dropdown', Dropdown)
 
 // Configure Stimulus development experience
 application.debug = false

--- a/app/javascript/controllers/timer_controller.js
+++ b/app/javascript/controllers/timer_controller.js
@@ -1,0 +1,34 @@
+import Timeago from 'stimulus-timeago'
+
+const formatDistanceToNow = (date) => {
+  let days = Math.floor(date / (1000 * 60 * 60 * 24))
+  let hours = Math.floor((date / (1000 * 60 * 60)) % 24)
+  let minutes = Math.floor((date / 1000 / 60) % 60)
+  let seconds = Math.floor((date / 1000) % 60)
+  let output = [days, hours, minutes].filter(time => time > 0)
+  if (seconds > 10) {
+    output.push(seconds)
+  } else {
+    output.push(`0${seconds}`)
+  }
+  return output.join(':')
+}
+
+export default class extends Timeago {
+  connect() {
+    super.connect()
+  }
+
+  load () {
+    const datetime = this.datetimeValue
+    const date = Date.parse(datetime)
+    const now = (new Date()).getTime()
+    this.isValid = !Number.isNaN(date) && date >= now
+
+    if (this.isValid) {
+      this.element.innerHTML = formatDistanceToNow(date - now)
+    } else {
+      this.element.innerHTML = '0:00'
+    }
+  }
+}

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -17,6 +17,7 @@ class Board < ApplicationRecord
   acts_as_paranoid
 
   has_many :columns, inverse_of: :board, dependent: :destroy
+  has_one :timer, inverse_of: :board, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
 

--- a/app/models/timer.rb
+++ b/app/models/timer.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: timers
+#
+#  id         :bigint           not null, primary key
+#  duration   :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  board_id   :bigint           not null
+#
+# Indexes
+#
+#  index_timers_on_board_id  (board_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (board_id => boards.id)
+#
+class Timer < ApplicationRecord
+  belongs_to :board, inverse_of: :timer
+  validates :duration, presence: true, numericality: {greater_than: 0}
+  validates :board_id, uniqueness: true
+
+  def ends_at
+    duration.seconds.since(created_at)
+  end
+end

--- a/app/views/boards/timers/create.turbo_stream.erb
+++ b/app/views/boards/timers/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace :flash do %>
+  <%= render(Flash::Component.new(flash: flash)) %>
+<% end %>

--- a/app/views/boards/timers/destroy.turbo_stream.erb
+++ b/app/views/boards/timers/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace :flash do %>
+  <%= render(Flash::Component.new(flash: flash)) %>
+<% end %>

--- a/app/views/boards/timers/show.html.erb
+++ b/app/views/boards/timers/show.html.erb
@@ -1,0 +1,1 @@
+<%= render(Timer::Component.new(timer: @timer)) %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -4,10 +4,13 @@ pin '@hotwired/stimulus', to: 'https://ga.jspm.io/npm:@hotwired/stimulus@3.1.0/d
 pin '@hotwired/stimulus', to: 'stimulus.min.js', preload: true
 pin '@hotwired/stimulus-loading', to: 'stimulus-loading.js', preload: true
 pin '@hotwired/turbo-rails', to: 'turbo.min.js', preload: true
-pin 'application', preload: true
 pin 'hotkeys-js', to: 'https://ga.jspm.io/npm:hotkeys-js@3.9.4/dist/hotkeys.esm.js'
+pin 'stimulus-dropdown', to: 'https://ga.jspm.io/npm:stimulus-dropdown@2.0.0/dist/stimulus-dropdown.es.js'
 pin 'stimulus-notification', to: 'https://ga.jspm.io/npm:stimulus-notification@2.0.0/dist/stimulus-notification.es.js'
 pin 'stimulus-rails-nested-form', to: 'https://ga.jspm.io/npm:stimulus-rails-nested-form@4.0.0/dist/stimulus-rails-nested-form.es.js'
 pin 'stimulus-reveal-controller', to: 'https://ga.jspm.io/npm:stimulus-reveal-controller@4.0.0/dist/stimulus-reveal-controller.es.js'
+pin 'stimulus-timeago', to: 'https://ga.jspm.io/npm:stimulus-timeago@4.0.0/dist/stimulus-timeago.es.js'
 pin 'stimulus-use', to: 'https://ga.jspm.io/npm:stimulus-use@0.50.0/dist/index.js'
+
+pin 'application', preload: true
 pin_all_from 'app/javascript/controllers', under: 'controllers'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,5 +53,10 @@ en:
     new:
       create: Create a new retrospective board.
       new: New Board
+    timers:
+      create:
+        success: Timer was successfully created.
+      destroy:
+        success: Timer was successfully destroyed.
     update:
       success: Board was successfully updated.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {omniauth_callbacks: 'users/omniauth_callbacks'}
 
-  resources :boards
+  resources :boards do
+    resource :timer, only: [:show, :create, :destroy], module: :boards
+  end
 
   devise_scope :user do
     namespace :users, as: :user do

--- a/db/migrate/20220726031753_create_timers.rb
+++ b/db/migrate/20220726031753_create_timers.rb
@@ -1,0 +1,9 @@
+class CreateTimers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :timers do |t|
+      t.integer :duration, null: false
+      t.belongs_to :board, null: false, foreign_key: true, index: {unique: true}
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_23_104921) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_26_031753) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,6 +31,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_23_104921) do
     t.index ["board_id", "name"], name: "index_columns_on_board_id_and_name", unique: true
   end
 
+  create_table "timers", force: :cascade do |t|
+    t.integer "duration", null: false
+    t.bigint "board_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["board_id"], name: "index_timers_on_board_id", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.string "name", null: false
@@ -41,4 +49,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_23_104921) do
   end
 
   add_foreign_key "columns", "boards"
+  add_foreign_key "timers", "boards"
 end

--- a/spec/components/timer/component_spec.rb
+++ b/spec/components/timer/component_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Timer::Component, type: :component do
+  subject(:rendered) { render_inline(described_class.new(timer: timer)) }
+
+  let(:board) { create(:board) }
+  let(:timer) { build(:timer, board: board) }
+
+  context 'when there is no timer' do
+    it { is_expected.to have_content('Start Timer').and have_button('5 minutes') }
+  end
+
+  context 'when there is a timer' do
+    let(:timer) { create(:timer, board: board, duration: 5.minutes) }
+
+    it { is_expected.to have_content('5:00').and have_button('Stop Timer') }
+  end
+
+  context 'when there is a timer with less than a minute' do
+    let(:timer) { create(:timer, board: board, duration: 42.seconds) }
+
+    it { is_expected.to have_content('42').and have_button('Stop Timer') }
+  end
+
+  context 'when there is a timer with just over a minute' do
+    let(:timer) { create(:timer, board: board, duration: 61.seconds) }
+
+    it { is_expected.to have_content('1:01').and have_button('Stop Timer') }
+  end
+end

--- a/spec/factories/timers.rb
+++ b/spec/factories/timers.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :timer do
+    board
+    sequence(:duration) { |n| n.minutes }
+  end
+end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -3,10 +3,12 @@ require 'rails_helper'
 RSpec.describe Board, type: :model do
   subject(:board) { build(:board) }
 
+  it { is_expected.to have_many(:columns).inverse_of(:board).dependent(:destroy) }
+  it { is_expected.to have_one(:timer).inverse_of(:board).dependent(:destroy) }
+
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name) }
   it { is_expected.to accept_nested_attributes_for(:columns) }
-  it { is_expected.to have_many(:columns).inverse_of(:board).dependent(:destroy) }
 
   describe '.most_recent' do
     context 'when there are no boards' do

--- a/spec/models/timer_spec.rb
+++ b/spec/models/timer_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Timer, type: :model do
+  subject(:timer) { build(:timer) }
+
+  it { is_expected.to belong_to(:board).inverse_of(:timer) }
+
+  it { is_expected.to validate_uniqueness_of(:board_id) }
+  it { is_expected.to validate_presence_of(:duration) }
+  it { is_expected.to validate_numericality_of(:duration).is_greater_than(0) }
+end

--- a/spec/requests/boards/timers_controller_spec.rb
+++ b/spec/requests/boards/timers_controller_spec.rb
@@ -1,0 +1,151 @@
+require 'rails_helper'
+
+RSpec.describe Boards::TimersController, type: :request do
+  let(:board) { create(:board) }
+  let(:user) { create(:user) }
+
+  describe 'GET #show' do
+    before { sign_in(user, scope: :user) }
+
+    def make_request(board_id)
+      get board_timer_url(board_id)
+    end
+
+    context 'when there is no timer' do
+      it 'renders a successful response' do
+        make_request(board.id)
+        expect(page).to have_content('Start Timer').and have_button('5 minutes')
+      end
+    end
+
+    context 'when there is a timer' do
+      before { create(:timer, board: board, duration: 6.minutes) }
+
+      it 'renders a successful response' do
+        make_request(board.id)
+        expect(page).to have_content('6:00').and have_button('Stop Timer')
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    before { sign_in(user, scope: :user) }
+
+    def make_request(board_id, timer_params)
+      post board_timer_url(board_id), params: {timer: timer_params}
+    end
+
+    context 'with valid parameters' do
+      it 'creates a new Timer' do
+        expect {
+          make_request(board.id, duration: 300)
+        }.to change(Timer, :count).by(1)
+      end
+
+      it 'redirects to the created timer' do
+        make_request(board.id, duration: 300)
+        expect(response).to redirect_to(board_timer_url(board))
+      end
+    end
+
+    context 'when a timer already exists' do
+      before { create(:timer, board: board) }
+
+      it 'creates a new Timer' do
+        expect {
+          make_request(board.id, duration: 300)
+        }.not_to change(Timer, :count)
+      end
+
+      it 'redirects to the created timer' do
+        make_request(board.id, duration: 300)
+        expect(response).to redirect_to(board_timer_url(board))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new Timer' do
+        expect {
+          make_request(board.id, duration: 0)
+        }.not_to change(Timer, :count)
+      end
+
+      it 'is not successful' do
+        make_request(board.id, duration: 0)
+        expect(response).not_to be_successful
+      end
+    end
+  end
+
+  describe 'POST #create.turbo_stream' do
+    before { sign_in(user, scope: :user) }
+
+    def make_request(board_id, timer_params)
+      post board_timer_url(board_id), params: {timer: timer_params}, headers: {Accept: Mime['turbo_stream'].to_s}
+    end
+
+    context 'with valid parameters' do
+      it 'creates a new Timer' do
+        expect { make_request(board.id, duration: 300) }.to change(Timer, :count).by(1)
+      end
+
+      it 'displays a flash message' do
+        make_request(board.id, duration: 300)
+        expect(page.css('turbo-stream[target=flash] turbo-frame#flash')).to have_text('Timer was successfully created')
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    before { sign_in(user, scope: :user) }
+
+    def make_request(board_id)
+      delete board_timer_url(board_id)
+    end
+
+    context 'with valid parameters' do
+      before { create(:timer, board: board) }
+
+      it 'destroys the requested timer' do
+        expect { make_request(board.id) }.to change(Timer, :count).by(-1)
+      end
+
+      it 'redirects to the timer page' do
+        make_request(board.id)
+        expect(response).to redirect_to(board_timer_url(board))
+      end
+    end
+
+    context 'when the timer does not exist' do
+      it 'destroys the requested timer' do
+        expect { make_request(board.id) }.not_to change(Timer, :count)
+      end
+
+      it 'redirects to the timer page' do
+        make_request(board.id)
+        expect(response).to redirect_to(board_timer_url(board))
+      end
+    end
+  end
+
+  describe 'DELETE #destroy.turbo_stream' do
+    before { sign_in(user, scope: :user) }
+
+    def make_request(board_id)
+      delete board_timer_url(board_id), headers: {Accept: Mime['turbo_stream'].to_s}
+    end
+
+    context 'with valid parameters' do
+      before { create(:timer, board: board) }
+
+      it 'destroys the requested timer' do
+        expect { make_request(board.id) }.to change(Timer, :count).by(-1)
+      end
+
+      it 'displays a flash message' do
+        make_request(board.id)
+        expect(page.css('turbo-stream[target=flash] turbo-frame#flash')).to have_text('Timer was successfully destroyed')
+      end
+    end
+  end
+end

--- a/spec/requests/boards_controller_spec.rb
+++ b/spec/requests/boards_controller_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe BoardsController, type: :request do
     end
   end
 
-  describe 'POST #create.turbo-stream' do
+  describe 'POST #create.turbo_stream' do
     before { sign_in(user, scope: :user) }
 
     def make_request(attributes)
@@ -248,7 +248,7 @@ RSpec.describe BoardsController, type: :request do
     end
   end
 
-  describe 'PATCH #update.turbo-stream' do
+  describe 'PATCH #update.turbo_stream' do
     let(:board) { create(:board) }
     let!(:column) { create(:column, board: board, name: 'Happy') }
 

--- a/spec/system/creating_a_retrospective_spec.rb
+++ b/spec/system/creating_a_retrospective_spec.rb
@@ -64,5 +64,17 @@ RSpec.describe 'Creating a retrospective', js: true do
     click_on 'Update Board'
 
     expect(page).to have_content('Retro of the Day')
+
+    click_on 'Start Timer'
+
+    click_on '5 minutes'
+
+    expect(page).to have_content(/\d:\d\d/)
+
+    page.find('button', text: /\d:\d\d/).click
+
+    click_on 'Stop Timer'
+
+    expect(page).to have_content('Start Timer')
   end
 end


### PR DESCRIPTION
## Describe your changes

When a Facilitator starts retro on a Board, they usually create a 5 minute Timer. The Timer then is broadcast to other Board participants.

## Checklist before hitting the green button
- [x] My commit messages mention the impacted stories, e.g. `[#12345,#678910]`
- [x] If appropriate, my commit messages flag story state, e.g. `[Finishes #1234]` or `[Fixes #4567]` or `[Delivers #78910]`
