### PR TITLE
Facilitator sees default Column names

### DIFF
--- a/app/components/board_column/component.html.erb
+++ b/app/components/board_column/component.html.erb
@@ -1,0 +1,5 @@
+<section class="flex flex-col flex-1 hidden sm:flex" data-tabs-target="panel">
+  <div class="px-6 pt-6 pb-4 bg-gray-50 hidden sm:block">
+    <h3 class="text-lg font-medium text-gray-900"><%= column.name %></h3>
+  </div>
+</section>

--- a/app/components/board_column/component.rb
+++ b/app/components/board_column/component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class BoardColumn::Component < ApplicationComponent
+  with_collection_parameter :column
+
+  attr_reader :column
+
+  def initialize(column:)
+    @column = column
+  end
+end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -106,7 +106,11 @@ class BoardsController < ApplicationController
 
   def new
     authorize(Board)
-    @board = BoardForm.new(board: Board.new(users: [current_user]), columns: [ColumnForm.new])
+    @board = BoardForm.new(board: Board.new(users: [current_user]), columns: [
+      ColumnForm.new(name: 'Happy'),
+      ColumnForm.new(name: 'Meh'),
+      ColumnForm.new(name: 'Sad')
+    ])
   end
 
   def edit

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -4,6 +4,7 @@ import Notification from 'stimulus-notification'
 import RailsNestedForm from 'stimulus-rails-nested-form'
 import Dropdown from 'stimulus-dropdown'
 import Clipboard from 'stimulus-clipboard'
+import { Tabs } from 'tailwindcss-stimulus-components'
 
 const application = Application.start()
 application.register('reveal', Reveal)
@@ -11,6 +12,7 @@ application.register('notification', Notification)
 application.register('nested-form', RailsNestedForm)
 application.register('dropdown', Dropdown)
 application.register('clipboard', Clipboard)
+application.register('tabs', Tabs)
 
 // Configure Stimulus development experience
 application.debug = false

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -5,3 +5,19 @@
     <%= render(BoardHeader::Component.new(board: @board)) %>
   </div>
 </header>
+
+<div class="flex-1 flex flex-col max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8" data-controller="tabs" data-tabs-active-tab="border-orange-500 text-orange-600 hover:border-orange-600" data-tabs-index="0">
+  <nav class="block sm:hidden">
+    <ul class="list-reset flex border-b space-x-8">
+      <% @board.columns.each do |column| %>
+        <li class="border-transparent hover:border-gray-300 border-b-2 font-medium text-sm" data-tabs-target="tab" data-action="click->tabs#change">
+          <a class="block text-gray-500 hover:text-gray-700 whitespace-nowrap py-4 px-1" href="#"><%= column.name %></a>
+        </li>
+      <% end %>
+    </ul>
+  </nav>
+
+  <div class="flex-1 flex sm:divide-x sm:divide-gray-200">
+    <%= render(BoardColumn::Component.with_collection(@board.columns)) %>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,9 +14,9 @@
   </head>
 
   <body class="h-full">
-    <div class="min-h-full">
+    <div class="flex flex-col min-h-full">
       <%= render(Header::Component.new) %>
-      <main class="relative py-10">
+      <main class="flex-1 flex flex-col relative pt-4">
         <%= yield %>
       </main>
     </div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -12,6 +12,7 @@ pin 'stimulus-rails-nested-form', to: 'https://ga.jspm.io/npm:stimulus-rails-nes
 pin 'stimulus-reveal-controller', to: 'https://ga.jspm.io/npm:stimulus-reveal-controller@4.0.0/dist/stimulus-reveal-controller.es.js'
 pin 'stimulus-timeago', to: 'https://ga.jspm.io/npm:stimulus-timeago@4.0.0/dist/stimulus-timeago.es.js'
 pin 'stimulus-use', to: 'https://ga.jspm.io/npm:stimulus-use@0.50.0/dist/index.js'
+pin 'tailwindcss-stimulus-components', to: 'https://ga.jspm.io/npm:tailwindcss-stimulus-components@3.0.4/dist/tailwindcss-stimulus-components.modern.js'
 
 pin 'application', preload: true
 pin_all_from 'app/javascript/controllers', under: 'controllers'

--- a/spec/components/board_column/component_spec.rb
+++ b/spec/components/board_column/component_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BoardColumn::Component, type: :component do
+  subject(:rendered) { render_inline(described_class.new(column: column)) }
+
+  let(:column) { create(:column, name: 'Happy') }
+
+  it { is_expected.to have_content('Happy') }
+end

--- a/spec/requests/boards_controller_spec.rb
+++ b/spec/requests/boards_controller_spec.rb
@@ -71,9 +71,9 @@ RSpec.describe BoardsController, type: :request do
 
     it 'renders a successful response' do
       make_request
-      expect(page).to have_field('Board name')
+      expect(page).to have_field('Board name').and have_button('Create Board')
+        .and have_field('Column name', with: 'Happy').and have_field('Column name', with: 'Meh').and have_field('Column name', with: 'Sad')
         .and have_button('Add Column').and have_button('Remove Column')
-        .and have_button('Create Board')
     end
 
     it 'does not accidentally create a board' do

--- a/spec/system/creating_a_retrospective_spec.rb
+++ b/spec/system/creating_a_retrospective_spec.rb
@@ -35,12 +35,8 @@ RSpec.describe 'Creating a retrospective', js: true do
 
     click_on 'Add Column'
 
-    within('#slideover li:first-of-type') do
-      fill_in 'Column name', with: 'Happy'
-    end
-
     within('#slideover li:last-of-type') do
-      fill_in 'Column name', with: 'Sad'
+      fill_in 'Column name', with: 'Unactionable'
     end
 
     click_on 'Create Board'


### PR DESCRIPTION
## Describe your changes

When a Facilitator creates a new board, we should provide guidance about default columns. This adds Happy/Meh/Sad as column names.

## Checklist before hitting the green button
- [x] My commit messages mention the impacted stories, e.g. `[#12345,#678910]`
- [x] If appropriate, my commit messages flag story state, e.g. `[Finishes #1234]` or `[Fixes #4567]` or `[Delivers #78910]`
