### PR TITLE
Participant adds a Topic under a Column

### DIFF
--- a/app/components/board_column/component.html.erb
+++ b/app/components/board_column/component.html.erb
@@ -1,7 +1,11 @@
 <%= turbo_frame_tag dom_id(column), class: 'contents' do %>
   <section class="flex flex-col flex-1 hidden sm:flex" data-tabs-target="panel" title="<%= column.name %>">
-    <div class="px-6 pt-6 pb-4 bg-gray-50 hidden sm:block">
-      <%= render(ColumnTitle::Component.new(column: column)) %>
+    <div class="px-6 pt-6 pb-4 bg-gray-50">
+      <div class="hidden sm:block">
+        <%= render(ColumnTitle::Component.new(column: column)) %>
+      </div>
+      <%= render(TopicForm::Component.new(topic: column.topics.new)) %>
     </div>
+    <%= turbo_frame_tag dom_id(column, :topics), src: board_column_topics_path(column.board, column) %>
   </section>
 <% end %>

--- a/app/components/topic/component.html.erb
+++ b/app/components/topic/component.html.erb
@@ -1,0 +1,5 @@
+<div class="relative px-6 py-5 flex items-center space-x-3 hover:bg-gray-50 focus-within:ring-2 focus-within:ring-inset focus-within:ring-pink-500">
+  <p class="text-sm font-medium text-gray-900">
+    <%= topic.name %>
+  </p>
+</div>

--- a/app/components/topic/component.rb
+++ b/app/components/topic/component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Topic::Component < ApplicationComponent
+  with_collection_parameter :topic
+
+  attr_reader :topic
+
+  def initialize(topic:)
+    @topic = topic
+  end
+end

--- a/app/components/topic_form/component.html.erb
+++ b/app/components/topic_form/component.html.erb
@@ -1,0 +1,27 @@
+<%= turbo_frame_tag dom_id(topic.column, :form) do %>
+  <%= form_with(model: topic, url: [topic.board, topic.column, :topics], class: 'flex sm:mt-2') do |form| %>
+    <div class="flex-1 min-w-0 mr-1">
+      <%= form.label :name, class: 'sr-only' %>
+      <div class="relative rounded-md shadow-sm">
+        <%= form.text_field :name, class: form.object.errors.include?(:name) ? 'block w-full pr-10 border-red-300 text-red-900 placeholder-red-300 focus:outline-none focus:ring-red-500 focus:border-red-500 sm:text-sm rounded-md' : 'block w-full border-gray-300 focus:outline-none focus:ring-orange-500 focus:border-orange-500 sm:text-sm rounded-md', aria: form.object.errors.include?(:name) ? {invalid: true, describedby: "#{topic.column.name}_topic_name_errors"} : {} %>
+        <% if form.object.errors.include?(:name) %>
+          <div class="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
+            <%= inline_svg_tag 'exclamation.svg', class: 'h-5 w-5 text-red-500' %>
+          </div>
+        <% end %>
+      </div>
+      <% if form.object.errors.include?(:name) %>
+        <p class="mt-2 text-sm text-red-600" id="<%= topic.column.name %>_topic_name_errors"><%= form.object.errors.full_messages_for(:name).first %></p>
+      <% end %>
+    </div>
+
+    <div>
+      <%= form.button type: :submit, class: 'inline-flex justify-center px-3.5 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500' do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4" />
+        </svg>
+        <span class="sr-only">Create Topic</span>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/components/topic_form/component.rb
+++ b/app/components/topic_form/component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class TopicForm::Component < ApplicationComponent
+  attr_reader :topic
+
+  def initialize(topic:)
+    @topic = topic
+  end
+end

--- a/app/controllers/boards/columns/topics_controller.rb
+++ b/app/controllers/boards/columns/topics_controller.rb
@@ -1,0 +1,43 @@
+class Boards::Columns::TopicsController < ApplicationController
+  helper_method :current_column
+
+  def index
+    authorize(Topic)
+    set_page_and_extract_portion_from policy_scope(current_column.topics), ordered_by: {created_at: :desc, id: :desc}
+  end
+
+  def new
+    authorize(current_board, :show?)
+    @topic = current_column.topics.new
+  end
+
+  def create
+    authorize(current_board, :show?)
+    @topic = current_column.topics.new(topic_params)
+
+    if @topic.save
+      current_board.broadcast_prepend_later_to(
+        current_board,
+        target: view_context.dom_id(current_column, :topics),
+        html: Topic::Component.new(topic: @topic).render_in(view_context)
+      )
+      redirect_to new_board_column_topic_path(current_board, current_column), notice: t('.success')
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def current_board
+    @board ||= Board.find(params[:board_id])
+  end
+
+  def current_column
+    @column ||= current_board.columns.find(params[:column_id])
+  end
+
+  def topic_params
+    params.require(:topic).permit(:name)
+  end
+end

--- a/app/models/column.rb
+++ b/app/models/column.rb
@@ -21,5 +21,7 @@ class Column < ApplicationRecord
 
   belongs_to :board, inverse_of: :columns
 
+  has_many :topics, inverse_of: :column, dependent: :destroy
+
   validates :name, presence: true, uniqueness: {scope: :board_id}
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: topics
+#
+#  id         :bigint           not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  column_id  :bigint           not null
+#
+# Indexes
+#
+#  index_topics_on_column_id  (column_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (column_id => columns.id)
+#
+class Topic < ApplicationRecord
+  include Hashid::Rails
+
+  belongs_to :column, inverse_of: :topics
+
+  has_one :board, through: :column
+
+  validates :name, presence: true
+end

--- a/app/policies/topic_policy.rb
+++ b/app/policies/topic_policy.rb
@@ -1,0 +1,27 @@
+class TopicPolicy < ApplicationPolicy
+  def index?
+    user.present?
+  end
+
+  def show?
+    TopicPolicy::Scope.new(user, Topic).resolve.exists?(id: record.id)
+  end
+
+  def create?
+    user.present?
+  end
+
+  def update?
+    show? && create?
+  end
+
+  def destroy?
+    show? && create?
+  end
+
+  class Scope < Scope
+    def resolve
+      scope.where(column_id: Column.where(board_id: BoardUser.where(user_id: user&.id).select(:board_id)).select(:column_id))
+    end
+  end
+end

--- a/app/views/boards/columns/topics/index.html.erb
+++ b/app/views/boards/columns/topics/index.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag dom_id(current_column, :topics) do %>
+  <%= render(Topic::Component.with_collection(@page.records)) %>
+<% end %>

--- a/app/views/boards/columns/topics/new.html.erb
+++ b/app/views/boards/columns/topics/new.html.erb
@@ -1,0 +1,1 @@
+<%= render(TopicForm::Component.new(topic: @topic)) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,13 +36,21 @@ en:
         name: Board name
       column:
         name: Column name
+      topic:
+        name: Topic name
   activemodel:
     attributes:
       board:
         name: Board name
       column:
         name: Column name
+      topic:
+        name: Topic name
   boards:
+    columns:
+      topics:
+        create:
+          success: Topic was successfully created.
     create:
       success: Board was successfully created.
     destroy:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,9 @@ Rails.application.routes.draw do
   resources :boards do
     resources :shares, only: [:show], param: :share_token, module: :boards
     resource :timer, only: [:show, :create, :destroy], module: :boards
+    resources :columns, only: [], module: :boards do
+      resources :topics, only: [:index, :new, :create], module: :columns
+    end
   end
 
   devise_scope :user do

--- a/db/migrate/20220728172101_create_topics.rb
+++ b/db/migrate/20220728172101_create_topics.rb
@@ -1,0 +1,9 @@
+class CreateTopics < ActiveRecord::Migration[7.0]
+  def change
+    create_table :topics do |t|
+      t.belongs_to :column, null: false, foreign_key: true, index: true
+      t.string :name, null: false
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_27_011137) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_28_172101) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,6 +48,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_27_011137) do
     t.index ["board_id"], name: "index_timers_on_board_id", unique: true
   end
 
+  create_table "topics", force: :cascade do |t|
+    t.bigint "column_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["column_id"], name: "index_topics_on_column_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.string "name", null: false
@@ -62,4 +70,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_27_011137) do
   add_foreign_key "board_users", "users"
   add_foreign_key "columns", "boards"
   add_foreign_key "timers", "boards"
+  add_foreign_key "topics", "columns"
 end

--- a/spec/components/topic/component_spec.rb
+++ b/spec/components/topic/component_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Topic::Component, type: :component do
+  subject(:rendered) { render_inline(described_class.new(topic: topic)) }
+
+  let(:topic) { create(:topic, name: 'Lunch') }
+
+  it { is_expected.to have_content('Lunch') }
+end

--- a/spec/components/topic_form/component_spec.rb
+++ b/spec/components/topic_form/component_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TopicForm::Component, type: :component do
+  subject(:rendered) { render_inline(described_class.new(topic: topic)) }
+
+  let(:column) { create(:column) }
+  let(:topic) { build(:topic, column: column, name: '') }
+
+  it { is_expected.to have_field('Topic name') }
+
+  context 'when there are errors' do
+    before { topic.valid? }
+
+    it { is_expected.to have_text("Topic name can't be blank") }
+  end
+end

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :topic do
+    column
+    sequence(:name) { |n| "Topic #{n}" }
+  end
+end

--- a/spec/models/column_spec.rb
+++ b/spec/models/column_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Column, type: :model do
   subject(:column) { build(:column) }
 
   it { is_expected.to belong_to(:board).inverse_of(:columns) }
+  it { is_expected.to have_many(:topics).inverse_of(:column).dependent(:destroy) }
+
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name).scoped_to(:board_id) }
 end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Topic, type: :model do
+  subject(:topic) { build(:topic) }
+
+  it { is_expected.to belong_to(:column).inverse_of(:topics) }
+  it { is_expected.to have_one(:board).through(:column) }
+
+  it { is_expected.to validate_presence_of(:name) }
+end

--- a/spec/policies/topic_policy_spec.rb
+++ b/spec/policies/topic_policy_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe TopicPolicy, type: :policy do
+  subject(:policy) { described_class }
+
+  let!(:user) { create(:user) }
+  let(:board) { create(:board) }
+  let(:column) { create(:column, board: board) }
+  let!(:topic) { create(:topic, column: column) }
+
+  describe TopicPolicy::Scope do
+    subject(:scope) { described_class.new(user, Topic).resolve }
+
+    context 'when the user is not associated with the board' do
+      it { is_expected.not_to include(topic) }
+    end
+
+    context 'when the user is associated with the board' do
+      before { create(:board_user, board: board, user: user) }
+
+      it { is_expected.to include(topic) }
+    end
+  end
+
+  permissions :show? do
+    context 'when the user is not associated with the board' do
+      it { is_expected.not_to permit(user, topic) }
+    end
+
+    context 'when the user is associated with the board' do
+      before { create(:board_user, board: board, user: user) }
+
+      it { is_expected.to permit(user, topic) }
+    end
+  end
+
+  permissions :index?, :new?, :create? do
+    it { is_expected.to permit(user, topic) }
+
+    context 'when the user is a guest' do
+      let(:user) { create(:user, :guest) }
+
+      it { is_expected.to permit(user, topic) }
+    end
+  end
+
+  permissions :edit?, :update?, :destroy? do
+    context 'when the user is not associated with the board' do
+      it { is_expected.not_to permit(user, topic) }
+    end
+
+    context 'when the user is associated with the board' do
+      before { create(:board_user, board: board, user: user) }
+
+      it { is_expected.to permit(user, topic) }
+    end
+
+    context 'when the user is a guest' do
+      let(:user) { create(:user, :guest) }
+
+      before { create(:board_user, board: board, user: user) }
+
+      it { is_expected.to permit(user, topic) }
+    end
+  end
+end

--- a/spec/requests/boards/columns/topics_controller_spec.rb
+++ b/spec/requests/boards/columns/topics_controller_spec.rb
@@ -1,0 +1,170 @@
+require 'rails_helper'
+
+RSpec.describe Boards::Columns::TopicsController, type: :request do
+  let(:board) { create(:board) }
+  let(:column) { create(:column, board: board) }
+
+  describe 'GET #index' do
+    before { create(:topic, column: column, name: 'beans') }
+
+    def make_request(board_id, column_id)
+      get board_column_topics_url(board_id, column_id)
+    end
+
+    context 'when the user is not signed in' do
+      it 'does not render the topic' do
+        make_request(board.id, column.id)
+        expect(page).to have_no_content('beans')
+      end
+    end
+
+    context 'when the user is not attached to the board' do
+      let(:user) { create(:user) }
+
+      before { sign_in(user, scope: :user) }
+
+      it 'does not render the topic' do
+        make_request(board.id, column.id)
+        expect(page).to have_no_content('beans')
+      end
+    end
+
+    context 'when the user is attached to the board' do
+      let(:user) { create(:user) }
+
+      before do
+        create(:board_user, board: board, user: user)
+        sign_in(user, scope: :user)
+      end
+
+      it 'renders the topic' do
+        make_request(board.id, column.id)
+        expect(page).to have_content('beans')
+      end
+    end
+
+    context 'when the guest is attached to the board' do
+      let(:user) { create(:user, :guest) }
+
+      before do
+        create(:board_user, board: board, user: user)
+        sign_in(user, scope: :user)
+      end
+
+      it 'renders the topic' do
+        make_request(board.id, column.id)
+        expect(page).to have_content('beans')
+      end
+    end
+  end
+
+  describe 'GET #new' do
+    def make_request(board_id, column_id)
+      get new_board_column_topic_url(board_id, column_id)
+    end
+
+    context 'when the user is not signed in' do
+      it 'blows up' do
+        expect { make_request(board.id, column.id) }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    context 'when the user is not attached to the board' do
+      let(:user) { create(:user) }
+
+      before { sign_in(user, scope: :user) }
+
+      it 'blows up' do
+        expect { make_request(board.id, column.id) }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    context 'when the user is attached to the board' do
+      let(:user) { create(:user) }
+
+      before do
+        create(:board_user, board: board, user: user)
+        sign_in(user, scope: :user)
+      end
+
+      it 'renders a form' do
+        make_request(board.id, column.id)
+        expect(page).to have_field('Topic name').and have_button('Create Topic')
+      end
+    end
+
+    context 'when the guest is attached to the board' do
+      let(:user) { create(:user, :guest) }
+
+      before do
+        create(:board_user, board: board, user: user)
+        sign_in(user, scope: :user)
+      end
+
+      it 'renders a form' do
+        make_request(board.id, column.id)
+        expect(page).to have_field('Topic name').and have_button('Create Topic')
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    def make_request(board_id, column_id, topic_params)
+      post board_column_topics_url(board_id, column_id), params: {topic: topic_params}
+    end
+
+    context 'when the user is not signed in' do
+      it 'blows up' do
+        expect { make_request(board.id, column.id, name: 'Taco') }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    context 'when the user is not attached to the board' do
+      let(:user) { create(:user) }
+
+      before { sign_in(user, scope: :user) }
+
+      it 'blows up' do
+        expect { make_request(board.id, column.id, name: 'Taco') }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    context 'when the user is attached to the board' do
+      let(:user) { create(:user) }
+
+      before do
+        create(:board_user, board: board, user: user)
+        sign_in(user, scope: :user)
+      end
+
+      it 'creates a topic' do
+        expect { make_request(board.id, column.id, name: 'Taco') }.to change(Topic, :count).by(1)
+      end
+
+      it 'sends a topic to the board channel' do
+        expect { make_request(board.id, column.id, name: 'Taco') }
+          .to have_enqueued_job(Turbo::Streams::ActionBroadcastJob)
+          .with(board.to_gid_param, hash_including(action: :prepend, html: a_string_including('Taco')))
+      end
+    end
+
+    context 'when the guest is attached to the board' do
+      let(:user) { create(:user, :guest) }
+
+      before do
+        create(:board_user, board: board, user: user)
+        sign_in(user, scope: :user)
+      end
+
+      it 'creates a topic' do
+        expect { make_request(board.id, column.id, name: 'Taco') }.to change(Topic, :count).by(1)
+      end
+
+      it 'sends a topic to the board channel' do
+        expect { make_request(board.id, column.id, name: 'Taco') }
+          .to have_enqueued_job(Turbo::Streams::ActionBroadcastJob)
+          .with(board.to_gid_param, hash_including(action: :prepend, html: a_string_including('Taco')))
+      end
+    end
+  end
+end

--- a/spec/requests/boards_controller_spec.rb
+++ b/spec/requests/boards_controller_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe BoardsController, type: :request do
         expect(response).to redirect_to(boards_url)
       end
 
-      it 'broadcasts to the boards channel' do
+      it 'sends a board to the boards channel' do
         expect { make_request(name: 'Thursday Retro', columns_attributes: {'0' => {name: 'Happy'}}) }
           .to have_enqueued_job(Turbo::Streams::ActionBroadcastJob)
           .with('boards', hash_including(action: :prepend, html: a_string_including('Thursday Retro')))

--- a/spec/system/creating_a_retrospective_spec.rb
+++ b/spec/system/creating_a_retrospective_spec.rb
@@ -116,6 +116,17 @@ RSpec.describe 'Creating a retrospective', js: true do
 
     expect(page).to have_content(/\d:\d\d/)
 
+    within('section[title="I want"]') do
+      fill_in 'Topic name', with: 'Tacos'
+      click_on 'Create Topic'
+    end
+
+    using_session(:guest) do
+      within('section[title="I want"]') do
+        expect(page).to have_content('Tacos')
+      end
+    end
+
     page.find('button', text: /\d:\d\d/).click
 
     click_on 'Stop Timer'


### PR DESCRIPTION
## Describe your changes

When a Participant views a Board, they can add Topics under each Column. It turns out that's really important for this application!

## Checklist before hitting the green button
- [x] My commit messages mention the impacted stories, e.g. `[#12345,#678910]`
- [x] If appropriate, my commit messages flag story state, e.g. `[Finishes #1234]` or `[Fixes #4567]` or `[Delivers #78910]`
