### PR TITLE
Participant sees confetti when a Board's Timer ends

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'devise'
 gem 'devise-guests'
 gem 'faker'
 gem 'geared_pagination', '~> 1.1'
-gem 'hotwire-livereload', '~> 1.2'
 gem 'image_processing', '~> 1.2'
 gem 'importmap-rails'
 gem 'inline_svg', github: 'jamesmartin/inline_svg', ref: 'e4c3d0d30f2c96a66fba264a849f8f056f6da738'
@@ -49,6 +48,7 @@ end
 
 group :development do
   gem 'annotate'
+  gem 'hotwire-livereload', '~> 1.2'
   gem 'pivotal_git_scripts'
   gem 'rack-mini-profiler'
   gem 'web-console'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -425,6 +425,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 An application to create retro boards
 
-* Ruby version - 3.0.0
+* Ruby version - 3.1.2
 * Rails version - 7.0.0
 
+
+# Setting up Google
+
+1. Visit the [project on the Google Developer Console](https://console.cloud.google.com/apis/credentials)
+2. Create a new Credential > OAuth credential > Web application, and name it after your machine
+3. Enter a redirect URL of http://127.0.0.1:3000/users/auth/google_oauth2/callback
+4. Copy the Client ID and Secret to your `.env` file as `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`

--- a/app/components/confetti/component.html.erb
+++ b/app/components/confetti/component.html.erb
@@ -1,0 +1,1 @@
+<canvas data-controller="confetti" class="fixed inset-0 w-full h-full pointer-events-none z-50" data-action="timer:end@window->confetti#fire" />

--- a/app/components/confetti/component.rb
+++ b/app/components/confetti/component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Confetti::Component < ApplicationComponent
+end

--- a/app/components/timer/component.html.erb
+++ b/app/components/timer/component.html.erb
@@ -3,7 +3,7 @@
     <div>
       <%= button_tag type: 'button', class: 'inline-flex justify-center w-full rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-orange-500', data: {action: 'dropdown#toggle click@window->dropdown#hide'} do %>
         <% if timer.persisted? %>
-          <time class="font-mono" datetime="<%= timer.ends_at.iso8601 %>" data-controller="timer" data-timer-refresh-interval-value="250" data-timer-datetime-value="<%= timer.ends_at.iso8601 %>"><%= time_remaining %></time>
+          <time class="font-mono" datetime="<%= timer.ends_at.iso8601 %>" data-controller="timer" data-timer-refresh-interval-value="1000" data-timer-datetime-value="<%= timer.ends_at.iso8601 %>"><%= time_remaining %></time>
         <% else %>
           Start Timer
         <% end %>
@@ -12,7 +12,7 @@
     </div>
 
     <div role="menu"
-      class="origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none"
+      class="origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50 focus:outline-none"
       data-dropdown-target="menu"
       data-transition-enter-from="opacity-0 scale-95"
       data-transition-enter-to="opacity-100 scale-100"

--- a/app/javascript/controllers/confetti_controller.js
+++ b/app/javascript/controllers/confetti_controller.js
@@ -1,0 +1,51 @@
+import { Controller } from '@hotwired/stimulus'
+import confetti from 'canvas-confetti'
+
+const REALISTIC_CONFETTI = [
+  {
+    origin: { y: 0.7 },
+    particleCount: 25,
+    spread: 26,
+    startVelocity: 55,
+  },
+  {
+    origin: { y: 0.7 },
+    particleCount: 20,
+    spread: 60,
+  },
+  {
+    origin: { y: 0.7 },
+    particleCount: 35,
+    spread: 100,
+    decay: 0.91,
+    scalar: 0.8
+  },
+  {
+    origin: { y: 0.7 },
+    particleCount: 10,
+    spread: 120,
+    startVelocity: 25,
+    decay: 0.92,
+    scalar: 1.2
+  },
+  {
+    origin: { y: 0.7 },
+    particleCount: 10,
+    spread: 120,
+    startVelocity: 45,
+  }
+]
+
+export default class extends Controller {
+  connect() {
+    this.confetti = confetti.create(this.element, {resize: true})
+  }
+
+  disconnect() {
+    this.confetti = null
+  }
+
+  fire() {
+    REALISTIC_CONFETTI.forEach(this.confetti)
+  }
+}

--- a/app/javascript/controllers/timer_controller.js
+++ b/app/javascript/controllers/timer_controller.js
@@ -29,6 +29,14 @@ export default class extends Timeago {
       this.element.innerHTML = formatDistanceToNow(date - now)
     } else {
       this.element.innerHTML = '0:00'
+      this.stopRefreshing()
+    }
+  }
+
+  stopRefreshing () {
+    if (this.refreshTimer) {
+      this.element.dispatchEvent(new CustomEvent('timer:end', {bubbles: true}))
+      clearInterval(this.refreshTimer)
     }
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,5 +26,6 @@
         <%= render(Flash::Component.new(flash: flash)) %>
       </div>
     </aside>
+    <%= render(Confetti::Component.new) %>
   </body>
 </html>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -16,3 +16,4 @@ pin 'tailwindcss-stimulus-components', to: 'https://ga.jspm.io/npm:tailwindcss-s
 
 pin 'application', preload: true
 pin_all_from 'app/javascript/controllers', under: 'controllers'
+pin 'canvas-confetti', to: 'https://ga.jspm.io/npm:canvas-confetti@1.5.1/dist/confetti.module.mjs'

--- a/spec/components/confetti/component_spec.rb
+++ b/spec/components/confetti/component_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Confetti::Component, type: :component do
+  subject(:rendered) { render_inline(described_class.new) }
+
+  it { is_expected.to have_css('canvas[data-action="timer:end@window->confetti#fire"]') }
+end


### PR DESCRIPTION
## Describe your changes

When a Participant sees that a Board's timer has run out, it's not visible enough, so we throw fire a confetti cannon.

## Checklist before hitting the green button
- [x] My commit messages mention the impacted stories, e.g. `[#12345,#678910]`
- [x] If appropriate, my commit messages flag story state, e.g. `[Finishes #1234]` or `[Fixes #4567]` or `[Delivers #78910]`
