### PR TITLE
Guest sees a flash alert when they try to create a timer

### DIFF
--- a/app/controllers/boards/timers_controller.rb
+++ b/app/controllers/boards/timers_controller.rb
@@ -61,6 +61,11 @@ class Boards::TimersController < ApplicationController
         format.html { render :show, status: :unprocessable_entity }
       end
     end
+  rescue Pundit::NotAuthorizedError
+    respond_to do |format|
+      format.turbo_stream { flash.now[:alert] = t('.alert') }
+      format.html { redirect_to board_timer_url(current_board), alert: t('.alert') }
+    end
   end
 
   def destroy
@@ -74,6 +79,11 @@ class Boards::TimersController < ApplicationController
       else
         format.html { redirect_to board_timer_url(current_board) }
       end
+    end
+  rescue Pundit::NotAuthorizedError
+    respond_to do |format|
+      format.turbo_stream { flash.now[:alert] = t('.alert') }
+      format.html { redirect_to board_timer_url(current_board), alert: t('.alert') }
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,8 +63,10 @@ en:
       new: New Board
     timers:
       create:
+        alert: You are not allowed to create a timer.
         success: Timer was successfully created.
       destroy:
+        alert: You are not allowed to stop a timer.
         success: Timer was successfully destroyed.
     shares:
       show:

--- a/spec/requests/boards/timers_controller_spec.rb
+++ b/spec/requests/boards/timers_controller_spec.rb
@@ -93,17 +93,12 @@ RSpec.describe Boards::TimersController, type: :request do
       post board_timer_url(board_id), params: {timer: timer_params}
     end
 
-    context 'when not logged in' do
-      it 'blows up' do
-        expect { make_request(board.id, duration: 300) }.to raise_error(Pundit::NotAuthorizedError)
-      end
-    end
-
     context 'when logged in as a user' do
       before { sign_in(user, scope: :user) }
 
-      it 'blows up' do
-        expect { make_request(board.id, duration: 300) }.to raise_error(Pundit::NotAuthorizedError)
+      it 'displays a flash message' do
+        make_request(board.id, duration: 300)
+        expect(flash[:alert]).to eq('You are not allowed to create a timer.')
       end
     end
 
@@ -112,8 +107,9 @@ RSpec.describe Boards::TimersController, type: :request do
 
       before { sign_in(user, scope: :user) }
 
-      it 'blows up' do
-        expect { make_request(board.id, duration: 300) }.to raise_error(Pundit::NotAuthorizedError)
+      it 'displays a flash message' do
+        make_request(board.id, duration: 300)
+        expect(flash[:alert]).to eq('You are not allowed to create a timer.')
       end
     end
 
@@ -152,8 +148,9 @@ RSpec.describe Boards::TimersController, type: :request do
         sign_in(user, scope: :user)
       end
 
-      it 'blows up' do
-        expect { make_request(board.id, duration: 300) }.to raise_error(Pundit::NotAuthorizedError)
+      it 'displays a flash message' do
+        make_request(board.id, duration: 300)
+        expect(flash[:alert]).to eq('You are not allowed to create a timer.')
       end
     end
 
@@ -207,17 +204,12 @@ RSpec.describe Boards::TimersController, type: :request do
       delete board_timer_url(board_id)
     end
 
-    context 'when not logged in' do
-      it 'blows up' do
-        expect { make_request(board.id) }.to raise_error(Pundit::NotAuthorizedError)
-      end
-    end
-
     context 'when logged in as a user' do
       before { sign_in(user, scope: :user) }
 
-      it 'blows up' do
-        expect { make_request(board.id) }.to raise_error(Pundit::NotAuthorizedError)
+      it 'displays a flash message' do
+        make_request(board.id)
+        expect(flash[:alert]).to eq('You are not allowed to stop a timer.')
       end
     end
 
@@ -226,8 +218,9 @@ RSpec.describe Boards::TimersController, type: :request do
 
       before { sign_in(user, scope: :user) }
 
-      it 'blows up' do
-        expect { make_request(board.id) }.to raise_error(Pundit::NotAuthorizedError)
+      it 'displays a flash message' do
+        make_request(board.id)
+        expect(flash[:alert]).to eq('You are not allowed to stop a timer.')
       end
     end
 
@@ -245,6 +238,20 @@ RSpec.describe Boards::TimersController, type: :request do
       it 'redirects to the timer page' do
         make_request(board.id)
         expect(response).to redirect_to(board_timer_url(board))
+      end
+    end
+
+    context 'when a guest is associated with a board with a timer' do
+      let(:user) { create(:user, :guest) }
+
+      before do
+        create(:board_user, board: board, user: user)
+        sign_in(user, scope: :user)
+      end
+
+      it 'displays a flash message' do
+        make_request(board.id)
+        expect(flash[:alert]).to eq('You are not allowed to stop a timer.')
       end
     end
 

--- a/spec/system/creating_a_retrospective_spec.rb
+++ b/spec/system/creating_a_retrospective_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Creating a retrospective', js: true do
 
     click_on 'Create Board'
 
-    expect(page).to have_content("Today's Retro").and have_text(I18n.l(Time.now.getlocal, format: :long))
+    expect(page).to have_content("Today's Retro").and have_text(I18n.l(Time.now.getlocal.to_date, format: '%B%e, %Y'))
     expect(page.all('li').size).to eq(16)
 
     scroll_to page.find('a', text: 'Next')
@@ -69,6 +69,11 @@ RSpec.describe 'Creating a retrospective', js: true do
       expect(page).to have_content("Today's Retro")
       expect(page).to have_css("img[alt='Minifast User']")
       expect(page).to have_css("img[alt='Testing Guest']")
+
+      click_on 'Timer'
+      click_on 'Start 5 minutes'
+
+      expect(page).to have_content('You are not allowed to create a timer.')
     end
 
     expect(page).to have_css("img[alt='Minifast User']")


### PR DESCRIPTION
Paired w/ @Vandersonnieri 

## Describe your changes

This PR handles showing guests a flash message when they try to create a timer. The messages lets them know that guests are not allowed to create timers.

## Checklist before hitting the green button
- [x] My commit messages mention the impacted stories, e.g. `[#12345,#678910]`
- [x] If appropriate, my commit messages flag story state, e.g. `[Finishes #1234]` or `[Fixes #4567]` or `[Delivers #78910]`
