### PR TITLE
Participant sees tabs that scroll horizontally on mobile

### DIFF
--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -7,7 +7,7 @@
 </header>
 
 <div class="flex-1 flex flex-col max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8" data-controller="tabs" data-tabs-active-tab="border-orange-500 text-orange-600 hover:border-orange-600" data-tabs-index="0">
-  <nav class="block sm:hidden">
+  <nav class="block overflow-hidden overflow-x-auto sm:hidden">
     <ul class="list-reset flex border-b space-x-8">
       <% @board.columns.each do |column| %>
         <li class="border-transparent hover:border-gray-300 border-b-2 font-medium text-sm" data-tabs-target="tab" data-action="click->tabs#change">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,3 +72,13 @@ en:
         failure: Unable to join board.
     update:
       success: Board was successfully updated.
+  date:
+    formats:
+      default: "%Y-%m-%d"
+      short: "%b %-e"
+      long: "%B %-e, %Y"
+  time:
+    formats:
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      short: "%d %b %H:%M"
+      long: "%B %-e, %Y %-l:%M %p"

--- a/spec/system/creating_a_retrospective_spec.rb
+++ b/spec/system/creating_a_retrospective_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Creating a retrospective', js: true do
 
     click_on 'Create Board'
 
-    expect(page).to have_content("Today's Retro").and have_text(I18n.l(Time.now.getlocal.to_date, format: :long))
+    expect(page).to have_content("Today's Retro").and have_text(I18n.l(Time.now.getlocal, format: :long))
     expect(page.all('li').size).to eq(16)
 
     scroll_to page.find('a', text: 'Next')


### PR DESCRIPTION
## Describe your changes

When a Participant views a Board on a smaller mobile device, they should be able to scroll the tabs horizontally rather than see a broken page layout

## Checklist before hitting the green button
- [x] My commit messages mention the impacted stories, e.g. `[#12345,#678910]`
- [x] If appropriate, my commit messages flag story state, e.g. `[Finishes #1234]` or `[Fixes #4567]` or `[Delivers #78910]`
