### PR TITLE
Facilitator does not see a new Tab on mobile

### DIFF
--- a/app/components/board_tabs/component.html.erb
+++ b/app/components/board_tabs/component.html.erb
@@ -1,0 +1,11 @@
+<%= turbo_frame_tag dom_id(board, :tabs) do %>
+  <nav class="block overflow-hidden overflow-x-auto sm:hidden">
+    <ul class="list-reset flex border-b space-x-8">
+      <% board.columns.each do |column| %>
+        <li class="border-transparent hover:border-gray-300 border-b-2 font-medium text-sm" data-tabs-target="tab" data-action="click->tabs#change">
+          <a class="block text-gray-500 hover:text-gray-700 whitespace-nowrap py-4 px-1" href="#"><%= column.name %></a>
+        </li>
+      <% end %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/components/board_tabs/component.rb
+++ b/app/components/board_tabs/component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class BoardTabs::Component < ApplicationComponent
+  attr_reader :board
+
+  def initialize(board:)
+    @board = board
+  end
+end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -95,6 +95,11 @@ class BoardsController < ApplicationController
         target: view_context.dom_id(board, :header),
         html: BoardHeader::Component.new(board: board).render_in(view_context)
       )
+      board.broadcast_replace_later_to(
+        board,
+        target: view_context.dom_id(board, :tabs),
+        html: BoardTabs::Component.new(board: board).render_in(view_context)
+      )
       removed_columns.each do |column|
         board.broadcast_remove_to(board, target: view_context.dom_id(column))
       end

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -7,15 +7,7 @@
 </header>
 
 <div class="flex-1 flex flex-col max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8" data-controller="tabs" data-tabs-active-tab="border-orange-500 text-orange-600 hover:border-orange-600" data-tabs-index="0">
-  <nav class="block overflow-hidden overflow-x-auto sm:hidden">
-    <ul class="list-reset flex border-b space-x-8">
-      <% @board.columns.each do |column| %>
-        <li class="border-transparent hover:border-gray-300 border-b-2 font-medium text-sm" data-tabs-target="tab" data-action="click->tabs#change">
-          <a class="block text-gray-500 hover:text-gray-700 whitespace-nowrap py-4 px-1" href="#"><%= column.name %></a>
-        </li>
-      <% end %>
-    </ul>
-  </nav>
+  <%= render(BoardTabs::Component.new(board: @board)) %>
 
   <div class="flex-1 flex sm:divide-x sm:divide-gray-200">
     <%= turbo_frame_tag dom_id(@board, :columns), class: 'contents' do %>

--- a/spec/components/board_tabs/component_spec.rb
+++ b/spec/components/board_tabs/component_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BoardTabs::Component, type: :component do
+  subject(:rendered) { render_inline(described_class.new(board: board)) }
+
+  let(:board) { create(:board, name: 'Cheeseboard') }
+
+  before do
+    create(:column, board_id: board.id, name: 'Cheeses')
+    create(:column, board_id: board.id, name: 'Olives')
+  end
+
+  it { is_expected.to have_content('Cheeses') }
+  it { is_expected.to have_content('Olives') }
+end

--- a/spec/requests/boards_controller_spec.rb
+++ b/spec/requests/boards_controller_spec.rb
@@ -299,6 +299,12 @@ RSpec.describe BoardsController, type: :request do
             .with(board.to_gid_param, hash_including(action: :replace, html: a_string_including('Friday Retro'), target: dom_id(board, 'header')))
         end
 
+        it 'broadcasts to replace columns on its tabs channel' do
+          expect { make_request(board.id, name: 'Friday Retro', columns_attributes: {'0' => {id: column.id, name: 'I like'}}) }
+            .to have_enqueued_job(Turbo::Streams::ActionBroadcastJob).once
+            .with(board.to_gid_param, hash_including(action: :replace, html: a_string_including('I like'), target: dom_id(board, 'tabs')))
+        end
+
         it 'broadcasts to a board to replace a column' do
           expect { make_request(board.id, name: 'Friday Retro', columns_attributes: {'0' => {id: column.id, name: 'I like'}}) }
             .to have_enqueued_job(Turbo::Streams::ActionBroadcastJob).once
@@ -403,6 +409,13 @@ RSpec.describe BoardsController, type: :request do
       expect { make_request(board.id, name: 'Friday Retro', columns_attributes: {'0' => {id: column.id, name: 'I like'}}) }.to have_enqueued_job(Turbo::Streams::ActionBroadcastJob).once.with(
         board.to_gid_param,
         hash_including(action: :replace, html: a_string_including('Friday Retro'), target: dom_id(board, 'header'))
+      )
+    end
+
+    it 'broadcasts to replace a board on its tabs channel' do
+      expect { make_request(board.id, name: 'Friday Retro', columns_attributes: {'0' => {id: column.id, name: 'I like'}}) }.to have_enqueued_job(Turbo::Streams::ActionBroadcastJob).once.with(
+        board.to_gid_param,
+        hash_including(action: :replace, html: a_string_including('I like'), target: dom_id(board, 'tabs'))
       )
     end
 


### PR DESCRIPTION
## Describe your changes

When a Facilitator changes a column name, all Participants connected to the Board see the change when using a mobile device

## Checklist before hitting the green button
- [x] My commit messages mention the impacted stories, e.g. `[#182919726]`
- [x] If appropriate, my commit messages flag story state, e.g. `[Finishes #182919726]` or `[Fixes #182919726]` or `[Delivers #182919726]`
