### PR TITLE
Participant sees dividers between columns

### DIFF
--- a/app/components/board_column/component.html.erb
+++ b/app/components/board_column/component.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag dom_id(column), class: 'contents' do %>
-  <section class="flex flex-col flex-1 hidden sm:flex" data-tabs-target="panel" title="<%= column.name %>">
+  <section class="flex flex-col flex-1 hidden sm:flex" data-tabs-target="panel" aria-label="<%= column.name %>">
     <div class="px-4 pt-6 pb-4 bg-gray-50">
       <div class="hidden sm:block">
         <%= render(ColumnTitle::Component.new(column: column)) %>

--- a/app/components/board_column/component.html.erb
+++ b/app/components/board_column/component.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag dom_id(column), class: 'contents' do %>
+<%= turbo_frame_tag dom_id(column), class: 'flex flex-col flex-1 hidden sm:flex', data: {tabs_target: 'panel'} do %>
   <section class="flex flex-col flex-1 hidden sm:flex" data-tabs-target="panel" aria-label="<%= column.name %>">
     <div class="px-4 pt-6 pb-4 bg-gray-50">
       <div class="hidden sm:block">

--- a/app/components/confetti/component.html.erb
+++ b/app/components/confetti/component.html.erb
@@ -1,1 +1,3 @@
-<canvas data-controller="confetti" class="fixed inset-0 w-full h-full pointer-events-none z-50" data-action="timer:end@window->confetti#fire" />
+<footer>
+  <canvas data-controller="confetti" class="fixed inset-0 w-full h-full pointer-events-none z-50" data-action="timer:end@window->confetti#fire" />
+</footer>

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -6,14 +6,14 @@
   </div>
 </header>
 
-<div class="flex-1 flex flex-col " data-controller="tabs" data-tabs-active-tab="border-orange-500 text-orange-600 hover:border-orange-600" data-tabs-index="0">
+<div class="flex-1 flex flex-col" data-controller="tabs" data-tabs-active-tab="border-orange-500 text-orange-600 hover:border-orange-600" data-tabs-index="0">
   <div class="sm:max-w-7xl sm:w-full sm:mx-auto sm:px-6 lg:px-8">
     <%= render(BoardTabs::Component.new(board: @board)) %>
   </div>
 
-  <div class="sm:max-w-7xl sm:w-full sm:mx-auto sm:px-6 lg:px-8">
-    <div class="flex-1 flex sm:divide-x sm:divide-gray-200">
-      <%= turbo_frame_tag dom_id(@board, :columns), class: 'contents' do %>
+  <div class="sm:flex-1 sm:flex sm:max-w-7xl sm:w-full sm:mx-auto sm:px-6 lg:px-8">
+    <div class="flex-1 flex sm:border-l sm:border-r sm:border-gray-200 sm:shadow-sm">
+      <%= turbo_frame_tag dom_id(@board, :columns), class: 'sm:flex-1 sm:flex sm:divide-x sm:divide-gray-200' do %>
         <%= render(BoardColumn::Component.with_collection(@board.columns.ranked)) %>
       <% end %>
     </div>

--- a/spec/system/creating_a_retrospective_spec.rb
+++ b/spec/system/creating_a_retrospective_spec.rb
@@ -121,13 +121,13 @@ RSpec.describe 'Creating a retrospective', js: true do
 
     expect(page).to have_content(/\d:\d\d/)
 
-    within('section[title="I want"]') do
+    within('section[aria-label="I want"]') do
       fill_in 'Topic name', with: 'Tacos'
       click_on 'Create Topic'
     end
 
     using_session(:guest) do
-      within('section[title="I want"]') do
+      within('section[aria-label="I want"]') do
         expect(page).to have_content('Tacos')
       end
     end


### PR DESCRIPTION
## Describe your changes

When a Participant looks at a Board, they should be able to see a clear separation between Columns

## Checklist before hitting the green button
- [x] My commit messages mention the impacted stories, e.g. `[#12345,#678910]`
- [x] If appropriate, my commit messages flag story state, e.g. `[Finishes #1234]` or `[Fixes #4567]` or `[Delivers #78910]`
