### PR TITLE
Participant sees a pleasing layout on mobile screens

### DIFF
--- a/app/components/board_column/component.html.erb
+++ b/app/components/board_column/component.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag dom_id(column), class: 'contents' do %>
   <section class="flex flex-col flex-1 hidden sm:flex" data-tabs-target="panel" title="<%= column.name %>">
-    <div class="px-6 pt-6 pb-4 bg-gray-50">
+    <div class="px-4 pt-6 pb-4 bg-gray-50">
       <div class="hidden sm:block">
         <%= render(ColumnTitle::Component.new(column: column)) %>
       </div>

--- a/app/components/board_header/component.html.erb
+++ b/app/components/board_header/component.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag dom_id(board, :header) do %>
-  <div class="pb-5 border-b border-gray-200 sm:flex sm:items-center sm:justify-between">
+  <div class="pb-5 border-b border-gray-200 px-4 sm:px-0 sm:flex sm:items-center sm:justify-between">
     <div class="flex items-center justify-between sm:block">
       <h2 class="text-3xl font-bold leading-7 text-gray-900 sm:text-3xl sm:truncate">
         <%= board.name %>
@@ -8,19 +8,21 @@
         <%= render(BoardUsers::Component.new(board: board)) %>
       </div>
     </div>
-    <div class="mt-4 flex justify-between sm:mt-0 sm:ml-4 sm:space-x-4">
-      <div class="sm:ml-4">
-        <%= link_to [:edit, board], class: 'inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500', data: {turbo_frame: 'slideover'} do %>
-          <%= inline_svg_tag 'board_header/pencil.svg', class: 'h-5 w-5 mr-2 text-gray-400' %>
-          Edit<span class="sr-only"> Board</span>
-        <% end %>
-      </div>
-      <div data-controller="clipboard" data-clipboard-success-content="Copied!">
-        <%= url_field_tag nil, board_share_url(board, board.share_token), class: 'hidden', readonly: true, autocomplete: 'off', data: {clipboard_target: 'source'} %>
-        <%= button_tag type: 'button', class: 'inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500', data: {action: 'clipboard#copy'} do %>
-          <%= inline_svg_tag 'board_header/link.svg', class: 'h-5 w-5 mr-2 text-gray-400' %>
-          <span class="sr-only">Copy </span><span data-clipboard-target="button">Invite</span><span class="sr-only"> Link</span>
-        <% end %>
+    <div class="mt-4 flex justify-between space-x-2 overflow-x-auto sm:mt-0 sm:ml-4 sm:space-x-4">
+      <div class="flex space-x-2 sm:space-x-4">
+        <div class="sm:ml-4">
+          <%= link_to [:edit, board], class: 'inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500', data: {turbo_frame: 'slideover'} do %>
+            <%= inline_svg_tag 'board_header/pencil.svg', class: 'h-5 w-5 mr-2 text-gray-400' %>
+            Edit<span class="sr-only"> Board</span>
+          <% end %>
+        </div>
+        <div data-controller="clipboard" data-clipboard-success-content="Copied!">
+          <%= url_field_tag nil, board_share_url(board, board.share_token), class: 'hidden', readonly: true, autocomplete: 'off', data: {clipboard_target: 'source'} %>
+          <%= button_tag type: 'button', class: 'inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500', data: {action: 'clipboard#copy'} do %>
+            <%= inline_svg_tag 'board_header/link.svg', class: 'h-5 w-5 mr-2 text-gray-400' %>
+            <span class="sr-only">Copy </span><span data-clipboard-target="button">Invite</span><span class="sr-only"> Link</span>
+          <% end %>
+        </div>
       </div>
       <div>
         <%= turbo_frame_tag dom_id(board, :timer), src: board_timer_path(board) %>

--- a/app/components/board_tabs/component.html.erb
+++ b/app/components/board_tabs/component.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag dom_id(board, :tabs) do %>
-  <nav class="block overflow-hidden overflow-x-auto sm:hidden">
-    <ul class="list-reset flex border-b space-x-8">
+  <nav class="block border-b px-4 sm:px-0 sm:hidden">
+    <ul class="overflow-hidden overflow-x-auto list-reset flex space-x-8">
       <% board.columns.each do |column| %>
         <li class="border-transparent hover:border-gray-300 border-b-2 font-medium text-sm" data-tabs-target="tab" data-action="click->tabs#change">
           <a class="block text-gray-500 hover:text-gray-700 whitespace-nowrap py-4 px-1" href="#"><%= column.name %></a>

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -1,17 +1,21 @@
 <%= turbo_stream_from @board %>
 
 <header>
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+  <div class="sm:max-w-7xl sm:mx-auto sm:px-6 lg:px-8">
     <%= render(BoardHeader::Component.new(board: @board)) %>
   </div>
 </header>
 
-<div class="flex-1 flex flex-col max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8" data-controller="tabs" data-tabs-active-tab="border-orange-500 text-orange-600 hover:border-orange-600" data-tabs-index="0">
-  <%= render(BoardTabs::Component.new(board: @board)) %>
+<div class="flex-1 flex flex-col " data-controller="tabs" data-tabs-active-tab="border-orange-500 text-orange-600 hover:border-orange-600" data-tabs-index="0">
+  <div class="sm:max-w-7xl sm:w-full sm:mx-auto sm:px-6 lg:px-8">
+    <%= render(BoardTabs::Component.new(board: @board)) %>
+  </div>
 
-  <div class="flex-1 flex sm:divide-x sm:divide-gray-200">
-    <%= turbo_frame_tag dom_id(@board, :columns), class: 'contents' do %>
-      <%= render(BoardColumn::Component.with_collection(@board.columns)) %>
-    <% end %>
+  <div class="sm:max-w-7xl sm:w-full sm:mx-auto sm:px-6 lg:px-8">
+    <div class="flex-1 flex sm:divide-x sm:divide-gray-200">
+      <%= turbo_frame_tag dom_id(@board, :columns), class: 'contents' do %>
+        <%= render(BoardColumn::Component.with_collection(@board.columns)) %>
+      <% end %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Describe your changes

When a Participant visits a Board on a mobile device, no matter what kind of layout that device has, they see a pleasing layout.

## Checklist before hitting the green button
- [x] My commit messages mention the impacted stories, e.g. `[#12345,#678910]`
- [x] If appropriate, my commit messages flag story state, e.g. `[Finishes #1234]` or `[Fixes #4567]` or `[Delivers #78910]`
