### PR TITLE
Participant sees a properly-formatted Timer

### DIFF
--- a/app/components/timer/component.rb
+++ b/app/components/timer/component.rb
@@ -8,8 +8,8 @@ class Timer::Component < ApplicationComponent
   end
 
   def time_remaining
-    if duration_parts.length < 1
-      duration_parts.last
+    if duration_parts.length <= 1
+      ['0', duration_parts].join(':')
     elsif duration_parts.last < 10
       (duration_parts[0..-2] + ['%02d' % duration_parts.last]).join(':')
     else

--- a/app/javascript/controllers/timer_controller.js
+++ b/app/javascript/controllers/timer_controller.js
@@ -5,8 +5,9 @@ const formatDistanceToNow = (date) => {
   let hours = Math.floor((date / (1000 * 60 * 60)) % 24)
   let minutes = Math.floor((date / 1000 / 60) % 60)
   let seconds = Math.floor((date / 1000) % 60)
-  let output = [days, hours, minutes].filter(time => time > 0)
-  if (seconds > 10) {
+  let output = [days, hours].filter(time => time > 0)
+  output.push(minutes)
+  if (seconds >= 10) {
     output.push(seconds)
   } else {
     output.push(`0${seconds}`)
@@ -25,10 +26,8 @@ export default class extends Timeago {
     const now = (new Date()).getTime()
     this.isValid = !Number.isNaN(date) && date >= now
 
-    if (this.isValid) {
-      this.element.innerHTML = formatDistanceToNow(date - now)
-    } else {
-      this.element.innerHTML = '0:00'
+    this.element.innerHTML = formatDistanceToNow(Math.max(0, date - now))
+    if (!this.isValid) {
       this.stopRefreshing()
     }
   }

--- a/spec/components/timer/component_spec.rb
+++ b/spec/components/timer/component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Timer::Component, type: :component do
   context 'when there is a timer with less than a minute' do
     let(:timer) { create(:timer, board: board, duration: 42.seconds) }
 
-    it { is_expected.to have_content('42').and have_button('Stop Timer') }
+    it { is_expected.to have_content('0:42').and have_button('Stop Timer') }
   end
 
   context 'when there is a timer with just over a minute' do


### PR DESCRIPTION
## Describe your changes

When a Participant is viewing a Timer, they should not see 1:010 remaining when there is 1 minute 10 seconds remaining. They should also see 0:59 when there are 59 seconds remaining.

## Checklist before hitting the green button
- [x] My commit messages mention the impacted stories, e.g. `[#12345,#678910]`
- [x] If appropriate, my commit messages flag story state, e.g. `[Finishes #1234]` or `[Fixes #4567]` or `[Delivers #78910]`
