### PR TITLE
Guest does not see an edit Board button

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,5 +1,11 @@
 class ApplicationComponent < ViewComponent::Base
   include Devise::Controllers::Helpers
+  include DeviseGuests::Controllers::Helpers
+  include Pundit::Authorization
   include Turbo::FramesHelper
   include Turbo::StreamsHelper
+
+  def pundit_user
+    current_or_guest_user
+  end
 end

--- a/app/components/board_header/component.html.erb
+++ b/app/components/board_header/component.html.erb
@@ -9,12 +9,14 @@
       </div>
     </div>
     <div class="mt-4 flex justify-between sm:mt-0 sm:ml-4 sm:space-x-4">
-      <div class="sm:ml-4">
-        <%= link_to [:edit, board], class: 'inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500', data: {turbo_frame: 'slideover'} do %>
-          <%= inline_svg_tag 'board_header/pencil.svg', class: 'h-5 w-5 mr-2 text-gray-400' %>
-          Edit<span class="sr-only"> Board</span>
-        <% end %>
-      </div>
+      <% if policy(board).update? %>
+        <div class="sm:ml-4">
+          <%= link_to [:edit, board], class: 'inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500', data: {turbo_frame: 'slideover'} do %>
+            <%= inline_svg_tag 'board_header/pencil.svg', class: 'h-5 w-5 mr-2 text-gray-400' %>
+            Edit<span class="sr-only"> Board</span>
+          <% end %>
+        </div>
+      <% end %>
       <div data-controller="clipboard" data-clipboard-success-content="Copied!">
         <%= url_field_tag nil, board_share_url(board, board.share_token), class: 'hidden', readonly: true, autocomplete: 'off', data: {clipboard_target: 'source'} %>
         <%= button_tag type: 'button', class: 'inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500', data: {action: 'clipboard#copy'} do %>


### PR DESCRIPTION
## Describe your changes

When a Guest views a Board, they do not see an Edit button.

There is a wicked edge case here:

When a Facilitator edits a Board, the BoardForm broadcasts a rendered BoardHeader::Component to all Participants listening to the Board.

This renders the Edit button, because the BoardHeader::Component is being rendered as the Facilitator. There are at least three possible solutions:

1. Instead of broadcasting the BoardHeader::Component, broadcast a `<turbo-frame>` element with a `src=` attribute set to the Board. This has the effect of re-requesting the Board.
2. Broadcast a BoardHeader::Component, rendered specifically for each listening Participant. Somehow.
3. Add a class to the Edit button that flags it as hidden if the Participant is a Guest.

## Checklist before hitting the green button
- [x] My commit messages mention the impacted stories, e.g. `[#12345,#678910]`
- [x] If appropriate, my commit messages flag story state, e.g. `[Finishes #1234]` or `[Fixes #4567]` or `[Delivers #78910]`
