### PR TITLE
Participant does not see when a Facilitator creates a Board

### DIFF
--- a/app/components/boards_list/component.html.erb
+++ b/app/components/boards_list/component.html.erb
@@ -1,16 +1,12 @@
-<div class="bg-white shadow overflow-hidden sm:rounded-md">
-  <ul id="boards" role="list" class="divide-y divide-gray-200">
-    <%= turbo_frame_tag [:boards, boards.number - 1] do %>
-      <%= render(Board::Component.with_collection(boards.records)) %>
-      <%= turbo_frame_tag [:boards, boards.number] do %>
-        <% unless boards.last? %>
-          <nav class="bg-white px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6" aria-label="Pagination">
-            <div class="flex-1 flex justify-between sm:justify-end">
-              <%= link_to 'Next', boards_path(page: boards.next_param), class: 'ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50', data: {controller: :autoclick} %>
-            </div>
-          </nav>
-        <% end %>
-      <% end %>
+<%= turbo_frame_tag [:boards, boards.number - 1] do %>
+  <%= render(Board::Component.with_collection(boards.records)) %>
+  <%= turbo_frame_tag [:boards, boards.number] do %>
+    <% unless boards.last? %>
+      <nav class="bg-white px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6" aria-label="Pagination">
+        <div class="flex-1 flex justify-between sm:justify-end">
+          <%= link_to 'Next', boards_path(page: boards.next_param), class: 'ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50', data: {controller: :autoclick} %>
+        </div>
+      </nav>
     <% end %>
-  </ul>
-</div>
+  <% end %>
+<% end %>

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -69,10 +69,13 @@ class BoardsController < ApplicationController
       return false unless [valid?, columns_create_valid?].all?
 
       board.update(name: name, columns_attributes: columns.map(&:to_h))
-      board.broadcast_prepend_later_to(
-        'boards',
-        html: Board::Component.new(board: board).render_in(view_context)
-      )
+      board.users.each do |user|
+        board.broadcast_prepend_later_to(
+          user,
+          target: view_context.dom_id(user, :boards),
+          html: Board::Component.new(board: board).render_in(view_context)
+        )
+      end
       true
     end
 
@@ -85,11 +88,13 @@ class BoardsController < ApplicationController
       new_columns = board.columns.to_a - old_columns
       remaining_columns = board.columns.to_a - new_columns
 
-      board.broadcast_replace_later_to(
-        'boards',
-        target: view_context.dom_id(board),
-        html: Board::Component.new(board: board).render_in(view_context)
-      )
+      board.users.each do |user|
+        board.broadcast_replace_later_to(
+          user,
+          target: view_context.dom_id(user, :boards),
+          html: Board::Component.new(board: board).render_in(view_context)
+        )
+      end
       board.broadcast_replace_later_to(
         board,
         target: view_context.dom_id(board, :header),

--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_stream_from 'boards' %>
+<%= turbo_stream_from current_user %>
 
 <header>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -11,6 +11,10 @@
 
 <div>
   <div class="mt-4 max-w-7xl mx-auto sm:px-6 lg:px-8">
-    <%= render(BoardsList::Component.new(boards: @page)) %>
+    <div class="bg-white shadow overflow-hidden sm:rounded-md">
+      <ul id="<%= dom_id(current_user, :boards) %>" role="list" class="divide-y divide-gray-200">
+        <%= render(BoardsList::Component.new(boards: @page)) %>
+      </ul>
+    </div>
   </div>
 </div>

--- a/spec/components/boards_list/component_spec.rb
+++ b/spec/components/boards_list/component_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe BoardsList::Component, type: :component do
   context 'when there is a board' do
     before { create(:board, name: 'Longboard') }
 
-    it { is_expected.to have_content('Longboard').and have_text(I18n.l(Time.current.utc.to_date, format: :long)) }
+    it { is_expected.to have_content('Longboard').and have_text(I18n.l(Time.current.utc, format: :long)) }
   end
 end

--- a/spec/requests/boards_controller_spec.rb
+++ b/spec/requests/boards_controller_spec.rb
@@ -163,10 +163,10 @@ RSpec.describe BoardsController, type: :request do
         expect(response).to redirect_to(boards_url)
       end
 
-      it 'sends a board to the boards channel' do
+      it 'sends a board to the user channel' do
         expect { make_request(name: 'Thursday Retro', columns_attributes: {'0' => {name: 'Happy'}}) }
           .to have_enqueued_job(Turbo::Streams::ActionBroadcastJob)
-          .with('boards', hash_including(action: :prepend, html: a_string_including('Thursday Retro')))
+          .with(user.to_gid_param, hash_including(action: :prepend, target: dom_id(user, :boards), html: a_string_including('Thursday Retro')))
       end
     end
 
@@ -287,10 +287,10 @@ RSpec.describe BoardsController, type: :request do
           expect(response).to redirect_to(board_url(board))
         end
 
-        it 'broadcasts to replace a board on the boards channel' do
+        it 'broadcasts to replace a board on the user channel' do
           expect { make_request(board.id, name: 'Friday Retro', columns_attributes: {'0' => {id: column.id, name: 'I like'}}) }
             .to have_enqueued_job(Turbo::Streams::ActionBroadcastJob).once
-            .with('boards', hash_including(action: :replace, html: a_string_including('Friday Retro'), target: dom_id(board)))
+            .with(user.to_gid_param, hash_including(action: :replace, html: a_string_including('Friday Retro'), target: dom_id(user, :boards)))
         end
 
         it 'broadcasts to replace a board on its header channel' do
@@ -398,10 +398,10 @@ RSpec.describe BoardsController, type: :request do
       expect(board.reload.attributes.symbolize_keys).to include(name: 'Friday Retro')
     end
 
-    it 'broadcasts to replace a board on the boards channel' do
+    it 'broadcasts to replace a board on the user channel' do
       expect { make_request(board.id, name: 'Friday Retro', columns_attributes: {'0' => {id: column.id, name: 'I like'}}) }.to have_enqueued_job(Turbo::Streams::ActionBroadcastJob).once.with(
-        'boards',
-        hash_including(action: :replace, html: a_string_including('Friday Retro'), target: dom_id(board))
+        user.to_gid_param,
+        hash_including(action: :replace, html: a_string_including('Friday Retro'), target: dom_id(user, :boards))
       )
     end
 


### PR DESCRIPTION
## Describe your changes

When a Facilitator creates a Board, logged-in Participants should not see the Board pop up in their list before they are invited.

## Checklist before hitting the green button
- [x] My commit messages mention the impacted stories, e.g. `[#12345,#678910]`
- [x] If appropriate, my commit messages flag story state, e.g. `[Finishes #1234]` or `[Fixes #4567]` or `[Delivers #78910]`
