### PR TITLE
Participant sees a Timer menu

### DIFF
--- a/app/components/board_header/component.html.erb
+++ b/app/components/board_header/component.html.erb
@@ -8,7 +8,7 @@
         <%= render(BoardUsers::Component.new(board: board)) %>
       </div>
     </div>
-    <div class="mt-4 flex justify-between space-x-2 overflow-x-auto sm:mt-0 sm:ml-4 sm:space-x-4">
+    <div class="mt-4 flex justify-between space-x-2 sm:mt-0 sm:ml-4 sm:space-x-4">
       <div class="flex space-x-2 sm:space-x-4">
         <div class="sm:ml-4">
           <%= link_to [:edit, board], class: 'inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500', data: {turbo_frame: 'slideover'} do %>

--- a/spec/system/creating_a_retrospective_spec.rb
+++ b/spec/system/creating_a_retrospective_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'Creating a retrospective', js: true do
       end
     end
 
-    within('section[title="I want"]') do
+    within('section[aria-label="I want"]') do
       expect(page).to have_content('Tacos')
       click_on 'Actions'
       click_on 'Delete Topic'


### PR DESCRIPTION
## Describe your changes

When a Participant views a Board, they should be see the timer menu.

## Checklist before hitting the green button
- [x] My commit messages mention the impacted stories, e.g. `[#12345,#678910]`
- [x] If appropriate, my commit messages flag story state, e.g. `[Finishes #1234]` or `[Fixes #4567]` or `[Delivers #78910]`
