### PR TITLE
Participant sees a Topic form

### DIFF
--- a/app/components/board_column/component.html.erb
+++ b/app/components/board_column/component.html.erb
@@ -1,11 +1,9 @@
-<%= turbo_frame_tag dom_id(column), class: 'flex flex-col flex-1 hidden sm:flex', data: {tabs_target: 'panel'} do %>
-  <section class="flex flex-col flex-1 hidden sm:flex" data-tabs-target="panel" aria-label="<%= column.name %>">
-    <div class="px-4 pt-6 pb-4 bg-gray-50">
-      <div class="hidden sm:block">
-        <%= render(ColumnTitle::Component.new(column: column)) %>
-      </div>
-      <%= render(TopicForm::Component.new(topic: column.topics.new)) %>
+<%= turbo_frame_tag dom_id(column), class: 'flex flex-col flex-1 hidden sm:flex', data: {tabs_target: 'panel'}, aria: {label: column.name} do %>
+  <div class="px-4 pt-6 pb-4 bg-gray-50">
+    <div class="hidden sm:block">
+      <%= render(ColumnTitle::Component.new(column: column)) %>
     </div>
-    <%= turbo_frame_tag dom_id(column, :topics), src: board_column_topics_path(column.board, column) %>
-  </section>
+    <%= render(TopicForm::Component.new(topic: column.topics.new)) %>
+  </div>
+  <%= turbo_frame_tag dom_id(column, :topics), src: board_column_topics_path(column.board, column) %>
 <% end %>

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -13,7 +13,7 @@
 
   <div class="sm:flex-1 sm:flex sm:max-w-7xl sm:w-full sm:mx-auto sm:px-6 lg:px-8">
     <div class="flex-1 flex sm:border-l sm:border-r sm:border-gray-200 sm:shadow-sm">
-      <%= turbo_frame_tag dom_id(@board, :columns), class: 'sm:flex-1 sm:flex sm:divide-x sm:divide-gray-200' do %>
+      <%= turbo_frame_tag dom_id(@board, :columns), class: 'flex-1 sm:flex sm:divide-x sm:divide-gray-200' do %>
         <%= render(BoardColumn::Component.with_collection(@board.columns.ranked)) %>
       <% end %>
     </div>

--- a/spec/system/creating_a_retrospective_spec.rb
+++ b/spec/system/creating_a_retrospective_spec.rb
@@ -121,18 +121,18 @@ RSpec.describe 'Creating a retrospective', js: true do
 
     expect(page).to have_content(/\d:\d\d/)
 
-    within('section[aria-label="I want"]') do
+    within('[aria-label="I want"]') do
       fill_in 'Topic name', with: 'Tacos'
       click_on 'Create Topic'
     end
 
     using_session(:guest) do
-      within('section[aria-label="I want"]') do
+      within('[aria-label="I want"]') do
         expect(page).to have_content('Tacos')
       end
     end
 
-    within('section[aria-label="I want"]') do
+    within('[aria-label="I want"]') do
       expect(page).to have_content('Tacos')
       click_on 'Actions'
       click_on 'Delete Topic'


### PR DESCRIPTION
## Describe your changes

When a Participant views a Board on a narrow screen, they should be able to see a Topic form.

## Checklist before hitting the green button
- [x] My commit messages mention the impacted stories, e.g. `[#12345,#678910]`
- [x] If appropriate, my commit messages flag story state, e.g. `[Finishes #1234]` or `[Fixes #4567]` or `[Delivers #78910]`
